### PR TITLE
refactor: Go 1.26 upgrade, linter modernization, and codebase-wide lint compliance

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,31 +15,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.25.1'
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
           args: --timeout=5m
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
-
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -34,9 +34,9 @@ jobs:
           echo "Release suffix: $RELEASE_SUFFIX"
 
       - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
       - name: Run apt-get update
         run: sudo apt-get update
       - name: Install cross-compiler for linux/arm64

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.25.1'
+          go-version-file: go.mod
       - name: Run apt-get update
         run: sudo apt-get update
       - name: Install cross-compiler for linux/arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,20 +8,16 @@ on:
 
 jobs:
   full_ci:
-    strategy:
-      matrix:
-        go_version: [ 1.25.x ]
-
     runs-on: ubuntu-latest
 
     steps:
       - name: checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version-file: go.mod
         
       - name: run tests
         run: go test -json ./... > test.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,96 +1,112 @@
 version: "2"
+
 run:
-  issues-exit-code: 1
+  timeout: 5m
+
 linters:
   default: none
   enable:
-    - asasalint
     - bidichk
     - bodyclose
-    - containedctx
     - copyloopvar
-    - decorder
-    - dogsled
-    - durationcheck
+    - cyclop
+    - dupword
     - errcheck
     - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - funlen
     - goconst
-    - gocyclo
-    - godot
-    - goheader
-    - goprintffuncname
+    - gocognit
+    - gocritic
     - gosec
     - govet
     - ineffassign
+    - intrange
     - misspell
-    - nakedret
+    - modernize
+    - nestif
     - nilerr
-    - nilnil
-    - nlreturn
+    - noctx
     - nolintlint
-    - nosprintfhostport
-    - prealloc
+    - perfsprint
     - predeclared
-    - promlinter
-    - reassign
+    - revive
+    - sloglint
     - staticcheck
-    - tagliatelle
-    - thelper
+    #- tagliatelle # TODO: re-enable once yaml tags are migrated to kebab-case
+    - testifylint
     - tparallel
     - unconvert
+    - usetesting
+    - unparam
     - unused
+    - usestdlibvars
+    - wastedassign
     - whitespace
-    - wsl_v5
+
   settings:
+    cyclop:
+      max-complexity: 30
+
+    funlen:
+      lines: 100
+      statements: 50
+
+    gocognit:
+      min-complexity: 20
+
     errcheck:
       check-type-assertions: true
-    goconst:
-      min-len: 2
-      min-occurrences: 3
-    gocritic:
-      enabled-tags:
-        - diagnostic
-        - experimental
-        - opinionated
-        - performance
-        - style
+
+    tagliatelle:
+      case:
+        rules:
+          yaml: kebab
+          json: camel
+
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+
     govet:
-      enable:
-        - shadow
+      enable-all: true
+      disable:
+        - fieldalignment
+      settings:
+        shadow:
+          strict: true
+
     nolintlint:
       require-explanation: true
       require-specific: true
-    wsl_v5:
-      allow-first-in-block: true
-      allow-whole-block: false
-      branch-max-lines: 2
+
+    sloglint:
+      no-global: all
+      context: scope
+
+    staticcheck:
+      checks:
+        - all
+
   exclusions:
-    generated: lax
+    paths:
+      - api/generated
+    rules:
+      - linters:
+          - funlen
+          - gocognit
+        path: _test\.go
     presets:
       - comments
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - linters:
-          - gocritic
-          - gosec
-          - wsl
-        path: _test\.go
-      - linters:
-          - goconst
-        path: cmd/tools/
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.26 AS builder
 WORKDIR /src
 COPY go.sum go.mod ./
 RUN go mod download

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -10,9 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	monitorConfigFile string
-)
+var monitorConfigFile string
 
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
@@ -21,10 +19,7 @@ var monitorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		initCommon()
 
-		err := monitor(cmd.Context())
-		if err != nil {
-			log.Fatal(err)
-		}
+		monitor(cmd.Context())
 
 		return nil
 	},
@@ -36,7 +31,7 @@ func init() {
 	monitorCmd.Flags().StringVar(&monitorConfigFile, "config", "config.yaml", "Config file (default is config.yaml)")
 }
 
-func monitor(ctx context.Context) error {
+func monitor(ctx context.Context) {
 	config, err := loadMonitorConfigFromFile(monitorConfigFile)
 	if err != nil {
 		log.Fatal(err)
@@ -47,13 +42,11 @@ func monitor(ctx context.Context) error {
 		log.Fatal(err)
 	}
 
-	if err := server.Start(ctx); err != nil {
-		log.Fatal(err)
+	if startErr := server.Start(ctx); startErr != nil {
+		log.Fatal(startErr)
 	}
 
 	log.Info("Splitoor monitor exited - cya!")
-
-	return nil
 }
 
 func loadMonitorConfigFromFile(file string) (*m.Config, error) {
@@ -63,8 +56,8 @@ func loadMonitorConfigFromFile(file string) (*m.Config, error) {
 
 	config := &m.Config{}
 
-	if err := defaults.Set(config); err != nil {
-		return nil, err
+	if defaultsErr := defaults.Set(config); defaultsErr != nil {
+		return nil, defaultsErr
 	}
 
 	yamlFile, err := os.ReadFile(file)
@@ -74,8 +67,8 @@ func loadMonitorConfigFromFile(file string) (*m.Config, error) {
 
 	type plain m.Config
 
-	if err := yaml.Unmarshal(yamlFile, (*plain)(config)); err != nil {
-		return nil, err
+	if unmarshalErr := yaml.Unmarshal(yamlFile, (*plain)(config)); unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
 
 	return config, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,9 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	log = logrus.New()
-)
+var log = logrus.New()
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
@@ -28,5 +26,4 @@ func Execute() {
 }
 
 func initCommon() {
-
 }

--- a/cmd/split.go
+++ b/cmd/split.go
@@ -37,16 +37,17 @@ func getSplitDefaultContractAddress(ctx context.Context, dpNode *execution.Node)
 
 	return nil, fmt.Errorf("contract address is required (chain id: %s)", chainID.String())
 }
+
 func parseRecipients(accounts, percentageAllocations string) (recipients []string, allocations []uint32, err error) {
 	acc := strings.Split(accounts, ",")
 	alloc := strings.Split(percentageAllocations, ",")
 
 	if len(acc) < 2 {
-		return nil, nil, fmt.Errorf("must specify at least 2 recipients")
+		return nil, nil, errors.New("must specify at least 2 recipients")
 	}
 
 	if len(acc) != len(alloc) {
-		return nil, nil, fmt.Errorf("number of accounts and percentage allocations must match")
+		return nil, nil, errors.New("number of accounts and percentage allocations must match")
 	}
 
 	allocations = make([]uint32, 0)
@@ -54,9 +55,9 @@ func parseRecipients(accounts, percentageAllocations string) (recipients []strin
 	var total uint32
 
 	for _, v := range alloc {
-		val, err := strconv.ParseUint(v, 10, 32)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid percentage allocation %s: %v", v, err)
+		val, parseErr := strconv.ParseUint(v, 10, 32)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("invalid percentage allocation %s: %w", v, parseErr)
 		}
 
 		allocation := uint32(val)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethpandaops/splitoor
 
-go 1.25.1
+go 1.26.1
 
 replace github.com/attestantio/go-eth2-client => github.com/attestantio/go-eth2-client v0.26.1-0.20250721122214-dc2928832acc
 

--- a/pkg/0xsplits/split/balance.go
+++ b/pkg/0xsplits/split/balance.go
@@ -2,7 +2,7 @@ package split
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 
 	"github.com/0xsequence/ethkit/ethcoder"
@@ -27,7 +27,7 @@ func (c *Client) GetETHBalance(ctx context.Context, node *execution.Node, contra
 
 	bigBalance, ok := values[0].(*big.Int)
 	if !ok {
-		return nil, fmt.Errorf("invalid balance")
+		return nil, errors.New("invalid balance")
 	}
 
 	return bigBalance, nil

--- a/pkg/0xsplits/split/create.go
+++ b/pkg/0xsplits/split/create.go
@@ -2,6 +2,7 @@ package split
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -15,6 +16,50 @@ import (
 	"github.com/0xsequence/ethkit/go-ethereum/crypto"
 	"github.com/ethpandaops/splitoor/pkg/ethereum/execution"
 )
+
+// waitForTransaction polls the node for a transaction until it is no longer
+// pending or the context is cancelled. It applies exponential backoff after
+// the first 10 attempts.
+func (c *Client) waitForTransaction(ctx context.Context, node *execution.Node, txHash string) error {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	attempt := 0
+	maxAttempts := 600 // 10 minutes worth of 1-second attempts
+
+	for attempt < maxAttempts {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled or timed out while waiting for transaction: %w", ctx.Err())
+		case <-ticker.C:
+			_, isPending, err := node.TransactionByHash(ctx, txHash)
+			if err != nil {
+				// If we're getting transient errors, continue polling
+				if strings.Contains(err.Error(), "not found") {
+					attempt++
+
+					continue
+				}
+
+				return err
+			}
+
+			if !isPending {
+				return nil
+			}
+
+			attempt++
+
+			// Apply exponential backoff after 10 attempts
+			if attempt > 10 {
+				backoffDuration := time.Duration(math.Min(float64(attempt-5), 30)) * time.Second
+				ticker.Reset(backoffDuration)
+			}
+		}
+	}
+
+	return fmt.Errorf("exceeded maximum polling attempts (%d) waiting for transaction", maxAttempts)
+}
 
 type CreateSplitParams struct {
 	Controller            string
@@ -40,11 +85,11 @@ func (c *CreateSplitParams) order() error {
 	return nil
 }
 
-func (c *CreateSplitParams) encode() ([]interface{}, error) {
+func (c *CreateSplitParams) encode() ([]any, error) {
 	// Create pairs for sorting
-	pairs := make([][2]interface{}, len(c.Accounts))
+	pairs := make([][2]any, len(c.Accounts))
 	for i := range c.Accounts {
-		pairs[i] = [2]interface{}{c.Accounts[i], c.PercentageAllocations[i]}
+		pairs[i] = [2]any{c.Accounts[i], c.PercentageAllocations[i]}
 	}
 
 	// Sort by account address with safe type assertions
@@ -82,7 +127,7 @@ func (c *CreateSplitParams) encode() ([]interface{}, error) {
 		allocations[i] = allocation
 	}
 
-	return []interface{}{
+	return []any{
 		accounts,
 		allocations,
 		c.DistributorFee,
@@ -96,7 +141,7 @@ func (c *Client) Create(ctx context.Context, node *execution.Node, contractABI *
 	}
 
 	if c.splitAddress != nil {
-		return nil, fmt.Errorf("split address is already set")
+		return nil, errors.New("split address is already set")
 	}
 
 	pKey, err := crypto.HexToECDSA(privateKey)
@@ -125,73 +170,28 @@ func (c *Client) Create(ctx context.Context, node *execution.Node, contractABI *
 
 	c.log.WithField("tx", *txHash).Info("Waiting for transaction to be included in a block")
 
-	// Add a ticker for controlled polling with backoff
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	// Track attempts for exponential backoff
-	attempt := 0
-	maxAttempts := 600 // 10 minutes worth of 1-second attempts
-
-	for attempt < maxAttempts {
-		select {
-		case <-pollCtx.Done():
-			// Context cancelled or timed out
-			return nil, fmt.Errorf("context cancelled or timed out while waiting for transaction: %w", pollCtx.Err())
-		case <-ticker.C:
-			// Time to check transaction status
-			var isPending bool
-
-			_, isPending, err = node.TransactionByHash(pollCtx, *txHash)
-			if err != nil {
-				// If we're getting transient errors, continue polling
-				if strings.Contains(err.Error(), "not found") {
-					attempt++
-
-					continue
-				}
-
-				return nil, err
-			}
-
-			if !isPending {
-				// Transaction is no longer pending, we can proceed
-				goto TransactionComplete
-			}
-
-			// Increment attempt counter
-			attempt++
-
-			// Apply exponential backoff after 10 attempts
-			if attempt > 10 {
-				backoffDuration := time.Duration(math.Min(float64(attempt-5), 30)) * time.Second
-				ticker.Reset(backoffDuration)
-			}
-		}
+	err = c.waitForTransaction(pollCtx, node, *txHash)
+	if err != nil {
+		return nil, err
 	}
 
-	// If we reach here, we've exceeded our maximum attempts
-	return nil, fmt.Errorf("exceeded maximum polling attempts (%d) waiting for transaction", maxAttempts)
-
-TransactionComplete:
 	receipt, err := node.TransactionReceipt(ctx, *txHash)
-
 	if err != nil {
 		return nil, err
 	}
 
 	if receipt == nil {
-		return nil, fmt.Errorf("nil transaction receipt returned")
+		return nil, errors.New("nil transaction receipt returned")
 	}
 
 	if len(receipt.Logs) == 0 {
-		return nil, fmt.Errorf("no logs found in transaction receipt")
+		return nil, errors.New("no logs found in transaction receipt")
 	}
 
 	// Safely access the first log
 	firstLog := receipt.Logs[0]
 	if firstLog == nil {
-		return nil, fmt.Errorf("nil log entry in transaction receipt")
+		return nil, errors.New("nil log entry in transaction receipt")
 	}
 
 	if len(firstLog.Topics) < 2 {
@@ -200,7 +200,7 @@ TransactionComplete:
 
 	// Safely access the second topic
 	if firstLog.Topics[1] == (common.Hash{}) {
-		return nil, fmt.Errorf("empty topic hash at index 1")
+		return nil, errors.New("empty topic hash at index 1")
 	}
 
 	splitAddress := common.HexToAddress(firstLog.Topics[1].Hex()).Hex()

--- a/pkg/0xsplits/split/distrubte.go
+++ b/pkg/0xsplits/split/distrubte.go
@@ -2,11 +2,10 @@ package split
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -41,11 +40,11 @@ func (p *DistributeETHParams) order() error {
 	return nil
 }
 
-func (p *DistributeETHParams) encode(splitAddress string) ([]interface{}, error) {
+func (p *DistributeETHParams) encode(splitAddress string) ([]any, error) {
 	// Create pairs for sorting
-	pairs := make([][2]interface{}, len(p.Accounts))
+	pairs := make([][2]any, len(p.Accounts))
 	for i := range p.Accounts {
-		pairs[i] = [2]interface{}{p.Accounts[i], p.PercentageAllocations[i]}
+		pairs[i] = [2]any{p.Accounts[i], p.PercentageAllocations[i]}
 	}
 
 	// Sort by account address with safe type assertions
@@ -88,7 +87,7 @@ func (p *DistributeETHParams) encode(splitAddress string) ([]interface{}, error)
 		distributorAddress = "0x0000000000000000000000000000000000000000"
 	}
 
-	return []interface{}{
+	return []any{
 		common.HexToAddress(splitAddress),
 		accounts,
 		allocations,
@@ -103,7 +102,7 @@ func (c *Client) DistributeETH(ctx context.Context, node *execution.Node, contra
 	}
 
 	if c.splitAddress == nil {
-		return fmt.Errorf("split address is not set")
+		return errors.New("split address is not set")
 	}
 
 	splitAddress := *c.splitAddress // Dereference safely after nil check
@@ -134,57 +133,11 @@ func (c *Client) DistributeETH(ctx context.Context, node *execution.Node, contra
 
 	c.log.WithField("tx", *txHash).Info("Waiting for transaction to be included in a block")
 
-	// Add a ticker for controlled polling with backoff
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	// Track attempts for exponential backoff
-	attempt := 0
-	maxAttempts := 600 // 10 minutes worth of 1-second attempts
-
-	for attempt < maxAttempts {
-		select {
-		case <-pollCtx.Done():
-			// Context cancelled or timed out
-			return fmt.Errorf("context cancelled or timed out while waiting for transaction: %w", pollCtx.Err())
-		case <-ticker.C:
-			// Time to check transaction status
-			var isPending bool
-
-			_, isPending, err = node.TransactionByHash(pollCtx, *txHash)
-			if err != nil {
-				// If we're getting transient errors, continue polling
-				if strings.Contains(err.Error(), "not found") {
-					attempt++
-
-					continue
-				}
-
-				return err
-			}
-
-			if !isPending {
-				// Transaction is no longer pending, we can proceed
-				goto TransactionComplete
-			}
-
-			// Increment attempt counter
-			attempt++
-
-			// Apply exponential backoff after 10 attempts
-			if attempt > 10 {
-				backoffDuration := time.Duration(math.Min(float64(attempt-5), 30)) * time.Second
-				ticker.Reset(backoffDuration)
-			}
-		}
+	if err = c.waitForTransaction(pollCtx, node, *txHash); err != nil {
+		return err
 	}
 
-	// If we reach here, we've exceeded our maximum attempts
-	return fmt.Errorf("exceeded maximum polling attempts (%d) waiting for transaction", maxAttempts)
-
-TransactionComplete:
 	receipt, err := node.TransactionReceipt(ctx, *txHash)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/0xsplits/split/hash.go
+++ b/pkg/0xsplits/split/hash.go
@@ -93,9 +93,9 @@ func encodeUint32ArrayPadded(arr []uint32) []byte {
 func encodeUint32Padded(value uint32) []byte {
 	b := make([]byte, 32)
 	b[28] = byte(value >> 24)
-	b[29] = byte(value >> 16)
-	b[30] = byte(value >> 8)
-	b[31] = byte(value)
+	b[29] = byte(value >> 16) //nolint:gosec // intentional byte extraction
+	b[30] = byte(value >> 8)  //nolint:gosec // intentional truncation to extract byte
+	b[31] = byte(value)       //nolint:gosec // intentional truncation to extract byte
 
 	return b
 }
@@ -103,9 +103,9 @@ func encodeUint32Padded(value uint32) []byte {
 func encodeUint32NoPad(value uint32) []byte {
 	b := make([]byte, 4)
 	b[0] = byte(value >> 24)
-	b[1] = byte(value >> 16)
-	b[2] = byte(value >> 8)
-	b[3] = byte(value)
+	b[1] = byte(value >> 16) //nolint:gosec // intentional truncation to extract byte
+	b[2] = byte(value >> 8)  //nolint:gosec // intentional truncation to extract byte
+	b[3] = byte(value)       //nolint:gosec // intentional truncation to extract byte
 
 	return b
 }

--- a/pkg/0xsplits/split/status.go
+++ b/pkg/0xsplits/split/status.go
@@ -2,7 +2,7 @@ package split
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/0xsequence/ethkit/ethcoder"
 	"github.com/0xsequence/ethkit/go-ethereum/common"
@@ -11,7 +11,7 @@ import (
 
 func (c *Client) GetController(ctx context.Context, node *execution.Node, contractABI *ethcoder.ABI) (*string, error) {
 	if c.splitAddress == nil {
-		return nil, fmt.Errorf("split address is required")
+		return nil, errors.New("split address is required")
 	}
 
 	calldata, err := contractABI.EncodeMethodCalldataFromStringValues("getController", []string{*c.splitAddress})
@@ -31,7 +31,7 @@ func (c *Client) GetController(ctx context.Context, node *execution.Node, contra
 
 	controllerAddress, ok := values[0].(common.Address)
 	if !ok {
-		return nil, fmt.Errorf("invalid controller address")
+		return nil, errors.New("invalid controller address")
 	}
 
 	controller := controllerAddress.Hex()
@@ -41,7 +41,7 @@ func (c *Client) GetController(ctx context.Context, node *execution.Node, contra
 
 func (c *Client) GetHash(ctx context.Context, node *execution.Node, contractABI *ethcoder.ABI) (*[32]uint8, error) {
 	if c.splitAddress == nil {
-		return nil, fmt.Errorf("split address is required")
+		return nil, errors.New("split address is required")
 	}
 
 	calldata, err := contractABI.EncodeMethodCalldataFromStringValues("getHash", []string{*c.splitAddress})
@@ -61,7 +61,7 @@ func (c *Client) GetHash(ctx context.Context, node *execution.Node, contractABI 
 
 	rsp, ok := values[0].([32]uint8)
 	if !ok {
-		return nil, fmt.Errorf("invalid hash")
+		return nil, errors.New("invalid hash")
 	}
 
 	return &rsp, nil

--- a/pkg/0xsplits/split/update.go
+++ b/pkg/0xsplits/split/update.go
@@ -2,6 +2,7 @@ package split
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -37,11 +38,11 @@ func (p *UpdateSplitParams) order() error {
 	return nil
 }
 
-func (p *UpdateSplitParams) encode(splitAddress string) ([]interface{}, error) {
+func (p *UpdateSplitParams) encode(splitAddress string) ([]any, error) {
 	// Create pairs for sorting
-	pairs := make([][2]interface{}, len(p.Accounts))
+	pairs := make([][2]any, len(p.Accounts))
 	for i := range p.Accounts {
-		pairs[i] = [2]interface{}{p.Accounts[i], p.PercentageAllocations[i]}
+		pairs[i] = [2]any{p.Accounts[i], p.PercentageAllocations[i]}
 	}
 
 	// Sort by account address with safe type assertions
@@ -79,7 +80,7 @@ func (p *UpdateSplitParams) encode(splitAddress string) ([]interface{}, error) {
 		allocations[i] = allocation
 	}
 
-	return []interface{}{
+	return []any{
 		common.HexToAddress(splitAddress),
 		accounts,
 		allocations,
@@ -93,7 +94,7 @@ func (c *Client) Update(ctx context.Context, node *execution.Node, contractABI *
 	}
 
 	if c.splitAddress == nil {
-		return nil, fmt.Errorf("split address is not set")
+		return nil, errors.New("split address is not set")
 	}
 
 	splitAddress := *c.splitAddress // Dereference safely after nil check

--- a/pkg/0xsplits/split/util.go
+++ b/pkg/0xsplits/split/util.go
@@ -1,23 +1,24 @@
 package split
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 )
 
 func ParseRecipients(accounts []string, percentageAllocations []uint32) (recipients []string, allocations []uint32, err error) {
 	if len(accounts) < 2 {
-		return nil, nil, fmt.Errorf("must specify at least 2 recipients")
+		return nil, nil, errors.New("must specify at least 2 recipients")
 	}
 
 	if len(accounts) != len(percentageAllocations) {
-		return nil, nil, fmt.Errorf("number of accounts and percentage allocations must match")
+		return nil, nil, errors.New("number of accounts and percentage allocations must match")
 	}
 
 	// Create pairs for sorting
-	pairs := make([][2]interface{}, len(accounts))
+	pairs := make([][2]any, len(accounts))
 	for i := range accounts {
-		pairs[i] = [2]interface{}{accounts[i], percentageAllocations[i]}
+		pairs[i] = [2]any{accounts[i], percentageAllocations[i]}
 	}
 
 	// Sort by account address with safe type assertions

--- a/pkg/0xsplits/split/withdraw.go
+++ b/pkg/0xsplits/split/withdraw.go
@@ -2,7 +2,7 @@ package split
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math/big"
 	"time"
 
@@ -20,7 +20,7 @@ type WithdrawParams struct {
 	Tokens      []string
 }
 
-func (w *WithdrawParams) encode() []interface{} {
+func (w *WithdrawParams) encode() []any {
 	withdrawETH := uint256.NewInt(0)
 	if w.WithdrawETH {
 		withdrawETH = uint256.NewInt(1)
@@ -31,7 +31,7 @@ func (w *WithdrawParams) encode() []interface{} {
 		tokens[i] = common.HexToAddress(w.Tokens[i])
 	}
 
-	return []interface{}{
+	return []any{
 		common.HexToAddress(w.Address),
 		withdrawETH.ToBig(),
 		tokens,
@@ -80,7 +80,7 @@ func (c *Client) Withdraw(ctx context.Context, node *execution.Node, contractABI
 	}
 
 	if receipt.Status == types.ReceiptStatusFailed {
-		return fmt.Errorf("transaction failed")
+		return errors.New("transaction failed")
 	}
 
 	return nil

--- a/pkg/ethereum/execution/node.go
+++ b/pkg/ethereum/execution/node.go
@@ -97,8 +97,8 @@ func (n *Node) Start(ctx context.Context) error {
 
 			n.log.WithField("service", service.Name()).Info("Starting service")
 
-			if err := service.Start(ctx); err != nil {
-				errs <- fmt.Errorf("failed to start service: %w", err)
+			if startErr := service.Start(ctx); startErr != nil {
+				errs <- fmt.Errorf("failed to start service: %w", startErr)
 			}
 
 			wg.Wait()
@@ -107,8 +107,8 @@ func (n *Node) Start(ctx context.Context) error {
 		n.log.Info("All services are ready")
 
 		for _, callback := range n.onReadyCallbacks {
-			if err := callback(ctx); err != nil {
-				errs <- fmt.Errorf("failed to run on ready callback: %w", err)
+			if cbErr := callback(ctx); cbErr != nil {
+				errs <- fmt.Errorf("failed to run on ready callback: %w", cbErr)
 			}
 		}
 	}()

--- a/pkg/ethereum/metrics.go
+++ b/pkg/ethereum/metrics.go
@@ -1,6 +1,7 @@
 package ethereum
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -44,9 +45,10 @@ func GetMetricsInstance(namespace, monitor string) *Metrics {
 	// Try to register but don't panic if it fails (already registered)
 	if err := prometheus.Register(nodesTotal); err != nil {
 		// If it's already registered, try to find the existing one
-		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
 			// If we can recover the existing metric, use it
-			if existing, ok := are.ExistingCollector.(*prometheus.GaugeVec); ok {
+			if existing, isGauge := are.ExistingCollector.(*prometheus.GaugeVec); isGauge {
 				nodesTotal = existing
 			}
 		}

--- a/pkg/ethereum/pool_test.go
+++ b/pkg/ethereum/pool_test.go
@@ -61,7 +61,7 @@ func TestPoolSafety(t *testing.T) {
 			// The actual implementation returns an empty (non-nil) slice
 			// which is the correct behavior, but we're actually testing that it doesn't panic
 			if execNodes != nil {
-				assert.Len(t, execNodes, 0)
+				assert.Empty(t, execNodes)
 			}
 
 			// This tests that the GetHealthyBeaconNodes doesn't panic with nil maps
@@ -69,7 +69,7 @@ func TestPoolSafety(t *testing.T) {
 			// The actual implementation returns an empty (non-nil) slice
 			// which is the correct behavior, but we're actually testing that it doesn't panic
 			if beaconNodes != nil {
-				assert.Len(t, beaconNodes, 0)
+				assert.Empty(t, beaconNodes)
 			}
 
 			// Test GetHealthyExecutionNode with nil maps
@@ -119,7 +119,7 @@ func TestPoolConcurrentAccess(t *testing.T) {
 	defer cancel()
 
 	// Run multiple goroutines that access the pool concurrently
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(5)
 
 		// Test reader methods

--- a/pkg/monitor/beaconchain/client.go
+++ b/pkg/monitor/beaconchain/client.go
@@ -2,6 +2,7 @@ package beaconchain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,13 +63,7 @@ func (c *client) GetValidators(ctx context.Context, pubkeys []string) (map[strin
 		return validators, nil
 	}
 
-	for i := 0; i < len(response.Data); i++ {
-		// Safe access to array elements with bounds check
-		if i >= len(response.Data) {
-			// This should never happen due to the loop condition, but it's a defensive check
-			break
-		}
-
+	for i := range response.Data {
 		validator := &response.Data[i]
 
 		// Only add to map if validator has a valid pubkey
@@ -88,7 +83,7 @@ func (c *client) GetValidator(ctx context.Context, pubkey string) (*Validator, e
 
 	// Check if response is nil
 	if response == nil {
-		return nil, fmt.Errorf("received nil response")
+		return nil, errors.New("received nil response")
 	}
 
 	if response.Status != StatusOK {

--- a/pkg/monitor/beaconchain/client_extended_test.go
+++ b/pkg/monitor/beaconchain/client_extended_test.go
@@ -41,7 +41,7 @@ func TestGetValidatorsSafetyChecks(t *testing.T) {
 
 	// Test with a nil Data field in response
 	validators, err := client.GetValidators(context.Background(), []string{"0x123"})
-	assert.NoError(t, err, "Should handle nil Data field without error")
+	require.NoError(t, err, "Should handle nil Data field without error")
 	assert.Empty(t, validators, "Should return empty map when Data is nil")
 
 	// Create a test server that returns a response with empty data array
@@ -59,7 +59,7 @@ func TestGetValidatorsSafetyChecks(t *testing.T) {
 
 	// Test with empty Data array
 	validators, err = client.GetValidators(context.Background(), []string{"0x123"})
-	assert.NoError(t, err, "Should handle empty Data array without error")
+	require.NoError(t, err, "Should handle empty Data array without error")
 	assert.Empty(t, validators, "Should return empty map when Data is empty")
 
 	// Create a test server that returns validators with nil entries
@@ -74,7 +74,7 @@ func TestGetValidatorsSafetyChecks(t *testing.T) {
 
 	// Test with Data array containing nil entries
 	validators, err = client.GetValidators(context.Background(), []string{"0x123"})
-	assert.NoError(t, err, "Should handle nil entries in Data array")
+	require.NoError(t, err, "Should handle nil entries in Data array")
 	assert.Len(t, validators, 1, "Should filter out nil validators")
 	assert.Contains(t, validators, "0x123", "Should contain the valid validator")
 }
@@ -102,7 +102,7 @@ func TestGetValidatorSafetyChecks(t *testing.T) {
 
 	// Test with a malformed response that can't be unmarshaled
 	_, err = client.GetValidator(context.Background(), "0x123")
-	assert.Error(t, err, "Should handle malformed response with error")
+	require.Error(t, err, "Should handle malformed response with error")
 
 	// Create a test server that returns an error status
 	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -119,7 +119,7 @@ func TestGetValidatorSafetyChecks(t *testing.T) {
 
 	// Test with error status
 	_, err = client.GetValidator(context.Background(), "0x123")
-	assert.Error(t, err, "Should handle error status with error")
+	require.Error(t, err, "Should handle error status with error")
 	assert.Contains(t, err.Error(), "error response from server")
 }
 
@@ -145,7 +145,7 @@ func TestRequestHandlingSafetyChecks(t *testing.T) {
 
 	// Test with non-200 status code
 	_, err = client.GetValidator(context.Background(), "0x123")
-	assert.Error(t, err, "Should handle non-200 status code with error")
+	require.Error(t, err, "Should handle non-200 status code with error")
 	assert.Contains(t, err.Error(), "status code")
 
 	// Test context cancellation
@@ -153,7 +153,7 @@ func TestRequestHandlingSafetyChecks(t *testing.T) {
 	cancel() // Cancel immediately
 
 	_, err = client.GetValidator(ctx, "0x123")
-	assert.Error(t, err, "Should handle cancelled context with error")
+	require.Error(t, err, "Should handle cancelled context with error")
 
 	// Test context timeout
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Nanosecond)
@@ -162,7 +162,7 @@ func TestRequestHandlingSafetyChecks(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	_, err = client.GetValidator(ctx, "0x123")
-	assert.Error(t, err, "Should handle context timeout with error")
+	require.Error(t, err, "Should handle context timeout with error")
 }
 
 // Tests for the public interface methods.

--- a/pkg/monitor/beaconchain/client_test.go
+++ b/pkg/monitor/beaconchain/client_test.go
@@ -89,8 +89,10 @@ func TestClient_GetValidators(t *testing.T) {
 				w.WriteHeader(tt.serverStatus)
 
 				if tt.serverResponse != nil {
-					err := json.NewEncoder(w).Encode(tt.serverResponse)
-					require.NoError(t, err)
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
 				}
 			}))
 			defer server.Close()
@@ -112,7 +114,7 @@ func TestClient_GetValidators(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedLen, len(validators))
+			assert.Len(t, validators, tt.expectedLen)
 
 			if tt.serverResponse != nil && tt.serverResponse.Data != nil {
 				for _, v := range tt.serverResponse.Data {
@@ -182,8 +184,10 @@ func TestClient_GetValidator(t *testing.T) {
 				w.WriteHeader(tt.serverStatus)
 
 				if tt.serverResponse != nil {
-					err := json.NewEncoder(w).Encode(tt.serverResponse)
-					require.NoError(t, err)
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
 				}
 			}))
 			defer server.Close()
@@ -225,6 +229,7 @@ func TestClient_GetConfig(t *testing.T) {
 	assert.Equal(t, 10, c.GetMaxRequestsPerMinute())
 	assert.Equal(t, time.Second, c.GetCheckInterval())
 }
+
 func TestClient_GetValidators_EmptyPubkeys(t *testing.T) {
 	serverCalled := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -232,11 +237,13 @@ func TestClient_GetValidators_EmptyPubkeys(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 
-		err := json.NewEncoder(w).Encode(&beaconchain.Response[[]beaconchain.Validator]{
+		if err := json.NewEncoder(w).Encode(&beaconchain.Response[[]beaconchain.Validator]{
 			Status: "OK",
 			Data:   []beaconchain.Validator{},
-		})
-		require.NoError(t, err)
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}))
 
 	defer server.Close()
@@ -261,11 +268,13 @@ func TestClient_APIKeyHeader(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, expectedAPIKey, r.Header.Get("apikey"))
 
-		err := json.NewEncoder(w).Encode(&beaconchain.Response[beaconchain.Validator]{
+		if err := json.NewEncoder(w).Encode(&beaconchain.Response[beaconchain.Validator]{
 			Status: "OK",
 			Data:   beaconchain.Validator{},
-		})
-		require.NoError(t, err)
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}))
 
 	defer server.Close()
@@ -288,11 +297,13 @@ func TestClient_URLConstruction(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.True(t, strings.HasSuffix(r.URL.Path, strings.Join(pubkeys, ",")))
 
-		err := json.NewEncoder(w).Encode(&beaconchain.Response[[]beaconchain.Validator]{
+		if err := json.NewEncoder(w).Encode(&beaconchain.Response[[]beaconchain.Validator]{
 			Status: "OK",
 			Data:   []beaconchain.Validator{},
-		})
-		require.NoError(t, err)
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}))
 
 	defer server.Close()

--- a/pkg/monitor/beaconchain/config.go
+++ b/pkg/monitor/beaconchain/config.go
@@ -1,7 +1,7 @@
 package beaconchain
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -20,15 +20,15 @@ func (c *Config) Validate() error {
 	}
 
 	if c.BatchSize <= 0 {
-		return fmt.Errorf("batch size must be greater than 0")
+		return errors.New("batch size must be greater than 0")
 	}
 
 	if c.MaxRequestsPerMinute <= 0 {
-		return fmt.Errorf("max requests per hour must be greater than 0")
+		return errors.New("max requests per hour must be greater than 0")
 	}
 
 	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
+		return errors.New("endpoint is required")
 	}
 
 	return nil

--- a/pkg/monitor/beaconchain/request.go
+++ b/pkg/monitor/beaconchain/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -13,7 +14,7 @@ import (
 func (c *client) get(ctx context.Context, path, url string) ([]byte, error) {
 	start := time.Now()
 
-	httpMethod := "GET"
+	httpMethod := http.MethodGet
 
 	c.metrics.ObserveRequest(httpMethod, path)
 
@@ -24,13 +25,13 @@ func (c *client) get(ctx context.Context, path, url string) ([]byte, error) {
 	defer func() {
 		rspCode := "none"
 		if rsp != nil {
-			rspCode = fmt.Sprintf("%d", rsp.StatusCode)
+			rspCode = strconv.Itoa(rsp.StatusCode)
 		}
 
 		c.metrics.ObserveResponse(httpMethod, path, rspCode, time.Since(start))
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -72,11 +73,11 @@ func (c *client) getValidators(ctx context.Context, pubkeys []string) (*Response
 	// response can be a single or list of validators
 	// still returns OK if validators are not found
 	resp := new(Response[[]Validator])
-	if err := json.Unmarshal(data, resp); err != nil {
+	if unmarshalErr := json.Unmarshal(data, resp); unmarshalErr != nil {
 		// Try single validator response
 		singleResp := new(Response[Validator])
 		if err2 := json.Unmarshal(data, singleResp); err2 != nil {
-			return nil, err
+			return nil, unmarshalErr
 		}
 
 		// After calling new() and successfully unmarshaling, singleResp can't be nil
@@ -108,8 +109,8 @@ func (c *client) getValidator(ctx context.Context, pubkey string) (*Response[Val
 	}
 
 	resp := new(Response[Validator])
-	if err := json.Unmarshal(data, resp); err != nil {
-		return nil, err
+	if unmarshalErr := json.Unmarshal(data, resp); unmarshalErr != nil {
+		return nil, unmarshalErr
 	}
 
 	return resp, nil

--- a/pkg/monitor/beaconchain/request_test.go
+++ b/pkg/monitor/beaconchain/request_test.go
@@ -43,9 +43,9 @@ func TestGetRequest(t *testing.T) {
 
 	// Test successful GET request
 	data, err := client.get(context.Background(), "test", server.URL)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, data)
-	assert.Equal(t, `{"status":"OK","data":{}}`, string(data))
+	assert.JSONEq(t, `{"status":"OK","data":{}}`, string(data))
 }
 
 func TestGetRequestErrors(t *testing.T) {
@@ -61,7 +61,7 @@ func TestGetRequestErrors(t *testing.T) {
 
 	// Test network error
 	_, err := client.get(context.Background(), "test", "http://invalid-url-that-does-not-exist.example")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Create a test server that returns a non-200 status
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +74,7 @@ func TestGetRequestErrors(t *testing.T) {
 
 	// Test non-200 status code
 	_, err = client.get(context.Background(), "test", server.URL)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "status code: 400")
 
 	// Create a server that times out
@@ -90,7 +90,7 @@ func TestGetRequestErrors(t *testing.T) {
 	defer cancel()
 
 	_, err = client.get(ctx, "test", server.URL)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGetValidatorsRequest(t *testing.T) {
@@ -132,7 +132,7 @@ func TestGetValidatorsRequest(t *testing.T) {
 
 	// Test getValidators with multiple pubkeys
 	resp, err := client.getValidators(context.Background(), []string{"0x123", "0x456"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "OK", resp.Status)
 	assert.Len(t, resp.Data, 2)
 	assert.Equal(t, "0x123", resp.Data[0].Pubkey)
@@ -166,7 +166,7 @@ func TestGetValidatorsSingleResponse(t *testing.T) {
 
 	// Test getValidators with response that's a single validator
 	resp, err := client.getValidators(context.Background(), []string{"0x123"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "OK", resp.Status)
 	assert.Len(t, resp.Data, 1)
 	assert.Equal(t, "0x123", resp.Data[0].Pubkey)
@@ -195,7 +195,7 @@ func TestGetValidatorsErrorResponse(t *testing.T) {
 
 	// GetValidators should return the error status
 	_, err := client.GetValidators(context.Background(), []string{"0x123"})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error response from server")
 }
 
@@ -254,5 +254,5 @@ func TestGetValidatorRequestInvalidJSON(t *testing.T) {
 
 	// Test getValidator with invalid JSON
 	_, err := client.getValidator(context.Background(), "0x123")
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/monitor/config.go
+++ b/pkg/monitor/config.go
@@ -1,7 +1,7 @@
 package monitor
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/ethpandaops/splitoor/pkg/ethereum"
 	"github.com/ethpandaops/splitoor/pkg/monitor/beaconchain"
@@ -35,7 +35,7 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c.Name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 
 	if err := c.Services.Validate(); err != nil {

--- a/pkg/monitor/event/safe/recovery_transaction_confirmations.go
+++ b/pkg/monitor/event/safe/recovery_transaction_confirmations.go
@@ -1,7 +1,7 @@
 package safe
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -81,10 +81,10 @@ func (v *RecoveryTransactionConfirmations) GetDescriptionText(includeMonitor, in
 	sb.WriteString(v.RecoveryTransactionID)
 
 	sb.WriteString("\nCurrent Confirmations: ")
-	sb.WriteString(fmt.Sprintf("%d", v.NumConfirmations))
+	sb.WriteString(strconv.Itoa(v.NumConfirmations))
 
 	sb.WriteString("\nExpected Confirmations: ")
-	sb.WriteString(fmt.Sprintf("%d", v.ExpectedConfirmations))
+	sb.WriteString(strconv.Itoa(v.ExpectedConfirmations))
 
 	return sb.String()
 }
@@ -117,11 +117,11 @@ func (v *RecoveryTransactionConfirmations) GetDescriptionMarkdown(includeMonitor
 	sb.WriteString("`\n")
 
 	sb.WriteString("**Current Confirmations:** ")
-	sb.WriteString(fmt.Sprintf("%d", v.NumConfirmations))
+	sb.WriteString(strconv.Itoa(v.NumConfirmations))
 	sb.WriteString("\n")
 
 	sb.WriteString("**Expected Confirmations:** ")
-	sb.WriteString(fmt.Sprintf("%d", v.ExpectedConfirmations))
+	sb.WriteString(strconv.Itoa(v.ExpectedConfirmations))
 
 	return sb.String()
 }
@@ -154,11 +154,11 @@ func (v *RecoveryTransactionConfirmations) GetDescriptionHTML(includeMonitor, in
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Current Confirmations:</strong> ")
-	sb.WriteString(fmt.Sprintf("%d", v.NumConfirmations))
+	sb.WriteString(strconv.Itoa(v.NumConfirmations))
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Expected Confirmations:</strong> ")
-	sb.WriteString(fmt.Sprintf("%d", v.ExpectedConfirmations))
+	sb.WriteString(strconv.Itoa(v.ExpectedConfirmations))
 	sb.WriteString("</p>")
 
 	return sb.String()

--- a/pkg/monitor/event/safe/threshold.go
+++ b/pkg/monitor/event/safe/threshold.go
@@ -1,7 +1,7 @@
 package safe
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -76,10 +76,10 @@ func (v *Threshold) GetDescriptionText(includeMonitor, includeGroup bool) string
 	sb.WriteString(v.SafeAddress)
 
 	sb.WriteString("\nActual Threshold: ")
-	sb.WriteString(fmt.Sprintf("%d", v.ActualThreshold))
+	sb.WriteString(strconv.Itoa(v.ActualThreshold))
 
 	sb.WriteString("\nExpected Threshold: ")
-	sb.WriteString(fmt.Sprintf("%d", v.ExpectedThreshold))
+	sb.WriteString(strconv.Itoa(v.ExpectedThreshold))
 
 	return sb.String()
 }
@@ -108,11 +108,11 @@ func (v *Threshold) GetDescriptionMarkdown(includeMonitor, includeGroup bool) st
 	sb.WriteString("`\n")
 
 	sb.WriteString("**Actual Threshold:** ")
-	sb.WriteString(fmt.Sprintf("%d", v.ActualThreshold))
+	sb.WriteString(strconv.Itoa(v.ActualThreshold))
 	sb.WriteString("\n")
 
 	sb.WriteString("**Expected Threshold:** ")
-	sb.WriteString(fmt.Sprintf("%d", v.ExpectedThreshold))
+	sb.WriteString(strconv.Itoa(v.ExpectedThreshold))
 
 	return sb.String()
 }
@@ -141,11 +141,11 @@ func (v *Threshold) GetDescriptionHTML(includeMonitor, includeGroup bool) string
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Actual Threshold:</strong> ")
-	sb.WriteString(fmt.Sprintf("%d", v.ActualThreshold))
+	sb.WriteString(strconv.Itoa(v.ActualThreshold))
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Expected Threshold:</strong> ")
-	sb.WriteString(fmt.Sprintf("%d", v.ExpectedThreshold))
+	sb.WriteString(strconv.Itoa(v.ExpectedThreshold))
 	sb.WriteString("</p>")
 
 	return sb.String()

--- a/pkg/monitor/event/safe/transaction_queue_excess.go
+++ b/pkg/monitor/event/safe/transaction_queue_excess.go
@@ -1,7 +1,7 @@
 package safe
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -74,7 +74,7 @@ func (v *TransactionQueueExcess) GetDescriptionText(includeMonitor, includeGroup
 	sb.WriteString(v.SafeAddress)
 
 	sb.WriteString("\nNumber of Transactions: ")
-	sb.WriteString(fmt.Sprintf("%d", v.NumTxs))
+	sb.WriteString(strconv.Itoa(v.NumTxs))
 
 	return sb.String()
 }
@@ -103,7 +103,7 @@ func (v *TransactionQueueExcess) GetDescriptionMarkdown(includeMonitor, includeG
 	sb.WriteString("`\n")
 
 	sb.WriteString("**Number of Transactions:** ")
-	sb.WriteString(fmt.Sprintf("%d", v.NumTxs))
+	sb.WriteString(strconv.Itoa(v.NumTxs))
 
 	return sb.String()
 }
@@ -132,7 +132,7 @@ func (v *TransactionQueueExcess) GetDescriptionHTML(includeMonitor, includeGroup
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Number of Transactions:</strong> ")
-	sb.WriteString(fmt.Sprintf("%d", v.NumTxs))
+	sb.WriteString(strconv.Itoa(v.NumTxs))
 	sb.WriteString("</p>")
 
 	return sb.String()

--- a/pkg/monitor/event/split/controller_test.go
+++ b/pkg/monitor/event/split/controller_test.go
@@ -11,140 +11,140 @@ import (
 	"github.com/ethpandaops/splitoor/pkg/monitor/event/split"
 )
 
-func TestController(t *testing.T) {
-	tests := []struct {
-		name               string
-		timestamp          time.Time
-		monitor            string
-		group              string
-		splitAddress       string
-		expectedController string
-		actualController   string
-		wantTitle          string
-		wantDesc           string
-	}{
-		{
-			name:               "basic event",
-			timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:            "test_monitor",
-			group:              "test_group",
-			splitAddress:       "0x123",
-			expectedController: "0x456",
-			actualController:   "0x789",
-			wantTitle:          "[test_monitor] Split controller has changed",
-			wantDesc: `
+var controllerTestCases = []struct {
+	name               string
+	timestamp          time.Time
+	monitor            string
+	group              string
+	splitAddress       string
+	expectedController string
+	actualController   string
+	wantTitle          string
+	wantDesc           string
+}{
+	{
+		name:               "basic event",
+		timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:            "test_monitor",
+		group:              "test_group",
+		splitAddress:       "0x123",
+		expectedController: "0x456",
+		actualController:   "0x789",
+		wantTitle:          "[test_monitor] Split controller has changed",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Expected Controller address: 0x456
 Actual Controller address: 0x789`,
-		},
-		{
-			name:               "same controller",
-			timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:            "test_monitor",
-			group:              "test_group",
-			splitAddress:       "0x123",
-			expectedController: "0x456",
-			actualController:   "0x456",
-			wantTitle:          "[test_monitor] Split controller has changed",
-			wantDesc: `
+	},
+	{
+		name:               "same controller",
+		timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:            "test_monitor",
+		group:              "test_group",
+		splitAddress:       "0x123",
+		expectedController: "0x456",
+		actualController:   "0x456",
+		wantTitle:          "[test_monitor] Split controller has changed",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Expected Controller address: 0x456
 Actual Controller address: 0x456`,
-		},
-		{
-			name:               "special characters",
-			timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:            "test!@#",
-			group:              "test$%^",
-			splitAddress:       "0x123&*()",
-			expectedController: "0x456{}[]",
-			actualController:   "0x789<>?",
-			wantTitle:          "[test!@#] Split controller has changed",
-			wantDesc: `
+	},
+	{
+		name:               "special characters",
+		timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:            "test!@#",
+		group:              "test$%^",
+		splitAddress:       "0x123&*()",
+		expectedController: "0x456{}[]",
+		actualController:   "0x789<>?",
+		wantTitle:          "[test!@#] Split controller has changed",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test!@#
 Group: test$%^
 Split Address: 0x123&*()
 Expected Controller address: 0x456{}[]
 Actual Controller address: 0x789<>?`,
-		},
-		{
-			name:               "empty addresses",
-			timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:            "test_monitor",
-			group:              "test_group",
-			splitAddress:       "",
-			expectedController: "",
-			actualController:   "",
-			wantTitle:          "[test_monitor] Split controller has changed",
-			wantDesc: `
+	},
+	{
+		name:               "empty addresses",
+		timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:            "test_monitor",
+		group:              "test_group",
+		splitAddress:       "",
+		expectedController: "",
+		actualController:   "",
+		wantTitle:          "[test_monitor] Split controller has changed",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 
 Expected Controller address: 
 Actual Controller address: `,
-		},
-		{
-			name:               "very long strings",
-			timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:            strings.Repeat("m", 100),
-			group:              strings.Repeat("g", 100),
-			splitAddress:       "0x" + strings.Repeat("1", 64),
-			expectedController: "0x" + strings.Repeat("2", 64),
-			actualController:   "0x" + strings.Repeat("3", 64),
-			wantTitle:          "[" + strings.Repeat("m", 100) + "] Split controller has changed",
-			wantDesc: `
+	},
+	{
+		name:               "very long strings",
+		timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:            strings.Repeat("m", 100),
+		group:              strings.Repeat("g", 100),
+		splitAddress:       "0x" + strings.Repeat("1", 64),
+		expectedController: "0x" + strings.Repeat("2", 64),
+		actualController:   "0x" + strings.Repeat("3", 64),
+		wantTitle:          "[" + strings.Repeat("m", 100) + "] Split controller has changed",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: ` + strings.Repeat("m", 100) + `
 Group: ` + strings.Repeat("g", 100) + `
 Split Address: 0x` + strings.Repeat("1", 64) + `
 Expected Controller address: 0x` + strings.Repeat("2", 64) + `
 Actual Controller address: 0x` + strings.Repeat("3", 64),
-		},
-		{
-			name:               "unicode characters",
-			timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:            "测试监控器",
-			group:              "测试组",
-			splitAddress:       "0x测试地址",
-			expectedController: "0x预期控制器",
-			actualController:   "0x实际控制器",
-			wantTitle:          "[测试监控器] Split controller has changed",
-			wantDesc: `
+	},
+	{
+		name:               "unicode characters",
+		timestamp:          time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:            "测试监控器",
+		group:              "测试组",
+		splitAddress:       "0x测试地址",
+		expectedController: "0x预期控制器",
+		actualController:   "0x实际控制器",
+		wantTitle:          "[测试监控器] Split controller has changed",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: 测试监控器
 Group: 测试组
 Split Address: 0x测试地址
 Expected Controller address: 0x预期控制器
 Actual Controller address: 0x实际控制器`,
-		},
-		{
-			name:               "edge timestamp",
-			timestamp:          time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
-			monitor:            "test_monitor",
-			group:              "test_group",
-			splitAddress:       "0x123",
-			expectedController: "0x456",
-			actualController:   "0x789",
-			wantTitle:          "[test_monitor] Split controller has changed",
-			wantDesc: `
+	},
+	{
+		name:               "edge timestamp",
+		timestamp:          time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
+		monitor:            "test_monitor",
+		group:              "test_group",
+		splitAddress:       "0x123",
+		expectedController: "0x456",
+		actualController:   "0x789",
+		wantTitle:          "[test_monitor] Split controller has changed",
+		wantDesc: `
 Timestamp: 9999-12-31 23:59:59 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Expected Controller address: 0x456
 Actual Controller address: 0x789`,
-		},
-	}
+	},
+}
 
-	for _, tt := range tests {
+func TestController(t *testing.T) {
+	for _, tt := range controllerTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			evt := split.NewController(
 				tt.timestamp,

--- a/pkg/monitor/event/split/hash_initial_state_test.go
+++ b/pkg/monitor/event/split/hash_initial_state_test.go
@@ -11,110 +11,110 @@ import (
 	"github.com/ethpandaops/splitoor/pkg/monitor/event/split"
 )
 
-func TestHashInitialState(t *testing.T) {
-	tests := []struct {
-		name         string
-		timestamp    time.Time
-		monitor      string
-		group        string
-		splitAddress string
-		hash         string
-		wantTitle    string
-		wantDesc     string
-	}{
-		{
-			name:         "basic event",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			hash:         "0x456",
-			wantTitle:    "[test_monitor] Split hash is in initial state",
-			wantDesc: `
+var hashInitialStateTestCases = []struct {
+	name         string
+	timestamp    time.Time
+	monitor      string
+	group        string
+	splitAddress string
+	hash         string
+	wantTitle    string
+	wantDesc     string
+}{
+	{
+		name:         "basic event",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		hash:         "0x456",
+		wantTitle:    "[test_monitor] Split hash is in initial state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Hash: 0x456`,
-		},
-		{
-			name:         "special characters",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test!@#",
-			group:        "test$%^",
-			splitAddress: "0x123&*()",
-			hash:         "0x456{}[]",
-			wantTitle:    "[test!@#] Split hash is in initial state",
-			wantDesc: `
+	},
+	{
+		name:         "special characters",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test!@#",
+		group:        "test$%^",
+		splitAddress: "0x123&*()",
+		hash:         "0x456{}[]",
+		wantTitle:    "[test!@#] Split hash is in initial state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test!@#
 Group: test$%^
 Split Address: 0x123&*()
 Hash: 0x456{}[]`,
-		},
-		{
-			name:         "empty hash",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "",
-			hash:         "",
-			wantTitle:    "[test_monitor] Split hash is in initial state",
-			wantDesc: `
+	},
+	{
+		name:         "empty hash",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "",
+		hash:         "",
+		wantTitle:    "[test_monitor] Split hash is in initial state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 
 Hash: `,
-		},
-		{
-			name:         "very long strings",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      strings.Repeat("m", 100),
-			group:        strings.Repeat("g", 100),
-			splitAddress: "0x" + strings.Repeat("1", 64),
-			hash:         "0x" + strings.Repeat("2", 64),
-			wantTitle:    "[" + strings.Repeat("m", 100) + "] Split hash is in initial state",
-			wantDesc: `
+	},
+	{
+		name:         "very long strings",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      strings.Repeat("m", 100),
+		group:        strings.Repeat("g", 100),
+		splitAddress: "0x" + strings.Repeat("1", 64),
+		hash:         "0x" + strings.Repeat("2", 64),
+		wantTitle:    "[" + strings.Repeat("m", 100) + "] Split hash is in initial state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: ` + strings.Repeat("m", 100) + `
 Group: ` + strings.Repeat("g", 100) + `
 Split Address: 0x` + strings.Repeat("1", 64) + `
 Hash: 0x` + strings.Repeat("2", 64),
-		},
-		{
-			name:         "unicode characters",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "测试监控器",
-			group:        "测试组",
-			splitAddress: "0x测试地址",
-			hash:         "0x预期哈希",
-			wantTitle:    "[测试监控器] Split hash is in initial state",
-			wantDesc: `
+	},
+	{
+		name:         "unicode characters",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "测试监控器",
+		group:        "测试组",
+		splitAddress: "0x测试地址",
+		hash:         "0x预期哈希",
+		wantTitle:    "[测试监控器] Split hash is in initial state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: 测试监控器
 Group: 测试组
 Split Address: 0x测试地址
 Hash: 0x预期哈希`,
-		},
-		{
-			name:         "edge timestamp",
-			timestamp:    time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			hash:         "0x456",
-			wantTitle:    "[test_monitor] Split hash is in initial state",
-			wantDesc: `
+	},
+	{
+		name:         "edge timestamp",
+		timestamp:    time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		hash:         "0x456",
+		wantTitle:    "[test_monitor] Split hash is in initial state",
+		wantDesc: `
 Timestamp: 9999-12-31 23:59:59 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Hash: 0x456`,
-		},
-	}
+	},
+}
 
-	for _, tt := range tests {
+func TestHashInitialState(t *testing.T) {
+	for _, tt := range hashInitialStateTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			evt := split.NewHashInitialState(
 				tt.timestamp,

--- a/pkg/monitor/event/split/hash_recovery_state_test.go
+++ b/pkg/monitor/event/split/hash_recovery_state_test.go
@@ -11,110 +11,110 @@ import (
 	"github.com/ethpandaops/splitoor/pkg/monitor/event/split"
 )
 
-func TestHashRecoveryState(t *testing.T) {
-	tests := []struct {
-		name         string
-		timestamp    time.Time
-		monitor      string
-		group        string
-		splitAddress string
-		hash         string
-		wantTitle    string
-		wantDesc     string
-	}{
-		{
-			name:         "basic event",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			hash:         "0x456",
-			wantTitle:    "[test_monitor] Split hash is in recovery state",
-			wantDesc: `
+var hashRecoveryStateTestCases = []struct {
+	name         string
+	timestamp    time.Time
+	monitor      string
+	group        string
+	splitAddress string
+	hash         string
+	wantTitle    string
+	wantDesc     string
+}{
+	{
+		name:         "basic event",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		hash:         "0x456",
+		wantTitle:    "[test_monitor] Split hash is in recovery state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Hash: 0x456`,
-		},
-		{
-			name:         "special characters",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test!@#",
-			group:        "test$%^",
-			splitAddress: "0x123&*()",
-			hash:         "0x456{}[]",
-			wantTitle:    "[test!@#] Split hash is in recovery state",
-			wantDesc: `
+	},
+	{
+		name:         "special characters",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test!@#",
+		group:        "test$%^",
+		splitAddress: "0x123&*()",
+		hash:         "0x456{}[]",
+		wantTitle:    "[test!@#] Split hash is in recovery state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test!@#
 Group: test$%^
 Split Address: 0x123&*()
 Hash: 0x456{}[]`,
-		},
-		{
-			name:         "empty hash",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "",
-			hash:         "",
-			wantTitle:    "[test_monitor] Split hash is in recovery state",
-			wantDesc: `
+	},
+	{
+		name:         "empty hash",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "",
+		hash:         "",
+		wantTitle:    "[test_monitor] Split hash is in recovery state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 
 Hash: `,
-		},
-		{
-			name:         "very long strings",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      strings.Repeat("m", 100),
-			group:        strings.Repeat("g", 100),
-			splitAddress: "0x" + strings.Repeat("1", 64),
-			hash:         "0x" + strings.Repeat("2", 64),
-			wantTitle:    "[" + strings.Repeat("m", 100) + "] Split hash is in recovery state",
-			wantDesc: `
+	},
+	{
+		name:         "very long strings",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      strings.Repeat("m", 100),
+		group:        strings.Repeat("g", 100),
+		splitAddress: "0x" + strings.Repeat("1", 64),
+		hash:         "0x" + strings.Repeat("2", 64),
+		wantTitle:    "[" + strings.Repeat("m", 100) + "] Split hash is in recovery state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: ` + strings.Repeat("m", 100) + `
 Group: ` + strings.Repeat("g", 100) + `
 Split Address: 0x` + strings.Repeat("1", 64) + `
 Hash: 0x` + strings.Repeat("2", 64),
-		},
-		{
-			name:         "unicode characters",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "测试监控器",
-			group:        "测试组",
-			splitAddress: "0x测试地址",
-			hash:         "0x预期哈希",
-			wantTitle:    "[测试监控器] Split hash is in recovery state",
-			wantDesc: `
+	},
+	{
+		name:         "unicode characters",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "测试监控器",
+		group:        "测试组",
+		splitAddress: "0x测试地址",
+		hash:         "0x预期哈希",
+		wantTitle:    "[测试监控器] Split hash is in recovery state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: 测试监控器
 Group: 测试组
 Split Address: 0x测试地址
 Hash: 0x预期哈希`,
-		},
-		{
-			name:         "edge timestamp",
-			timestamp:    time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			hash:         "0x456",
-			wantTitle:    "[test_monitor] Split hash is in recovery state",
-			wantDesc: `
+	},
+	{
+		name:         "edge timestamp",
+		timestamp:    time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		hash:         "0x456",
+		wantTitle:    "[test_monitor] Split hash is in recovery state",
+		wantDesc: `
 Timestamp: 9999-12-31 23:59:59 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Hash: 0x456`,
-		},
-	}
+	},
+}
 
-	for _, tt := range tests {
+func TestHashRecoveryState(t *testing.T) {
+	for _, tt := range hashRecoveryStateTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			evt := split.NewHashRecoveryState(
 				tt.timestamp,

--- a/pkg/monitor/event/split/hash_unknown_state_test.go
+++ b/pkg/monitor/event/split/hash_unknown_state_test.go
@@ -11,140 +11,140 @@ import (
 	"github.com/ethpandaops/splitoor/pkg/monitor/event/split"
 )
 
-func TestHashUnknownState(t *testing.T) {
-	tests := []struct {
-		name         string
-		timestamp    time.Time
-		monitor      string
-		group        string
-		splitAddress string
-		expectedHash string
-		actualHash   string
-		wantTitle    string
-		wantDesc     string
-	}{
-		{
-			name:         "basic event",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			expectedHash: "0x456",
-			actualHash:   "0x789",
-			wantTitle:    "[test_monitor] Split hash is in unknown state",
-			wantDesc: `
+var hashUnknownStateTestCases = []struct {
+	name         string
+	timestamp    time.Time
+	monitor      string
+	group        string
+	splitAddress string
+	expectedHash string
+	actualHash   string
+	wantTitle    string
+	wantDesc     string
+}{
+	{
+		name:         "basic event",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		expectedHash: "0x456",
+		actualHash:   "0x789",
+		wantTitle:    "[test_monitor] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Expected Hash: 0x456
 Actual Hash: 0x789`,
-		},
-		{
-			name:         "same hash",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			expectedHash: "0x456",
-			actualHash:   "0x456",
-			wantTitle:    "[test_monitor] Split hash is in unknown state",
-			wantDesc: `
+	},
+	{
+		name:         "same hash",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		expectedHash: "0x456",
+		actualHash:   "0x456",
+		wantTitle:    "[test_monitor] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Expected Hash: 0x456
 Actual Hash: 0x456`,
-		},
-		{
-			name:         "special characters",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test!@#",
-			group:        "test$%^",
-			splitAddress: "0x123&*()",
-			expectedHash: "0x456{}[]",
-			actualHash:   "0x789<>?",
-			wantTitle:    "[test!@#] Split hash is in unknown state",
-			wantDesc: `
+	},
+	{
+		name:         "special characters",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test!@#",
+		group:        "test$%^",
+		splitAddress: "0x123&*()",
+		expectedHash: "0x456{}[]",
+		actualHash:   "0x789<>?",
+		wantTitle:    "[test!@#] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test!@#
 Group: test$%^
 Split Address: 0x123&*()
 Expected Hash: 0x456{}[]
 Actual Hash: 0x789<>?`,
-		},
-		{
-			name:         "empty hashes",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "",
-			expectedHash: "",
-			actualHash:   "",
-			wantTitle:    "[test_monitor] Split hash is in unknown state",
-			wantDesc: `
+	},
+	{
+		name:         "empty hashes",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "",
+		expectedHash: "",
+		actualHash:   "",
+		wantTitle:    "[test_monitor] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 
 Expected Hash: 
 Actual Hash: `,
-		},
-		{
-			name:         "very long strings",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      strings.Repeat("m", 100),
-			group:        strings.Repeat("g", 100),
-			splitAddress: "0x" + strings.Repeat("1", 64),
-			expectedHash: "0x" + strings.Repeat("2", 64),
-			actualHash:   "0x" + strings.Repeat("3", 64),
-			wantTitle:    "[" + strings.Repeat("m", 100) + "] Split hash is in unknown state",
-			wantDesc: `
+	},
+	{
+		name:         "very long strings",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      strings.Repeat("m", 100),
+		group:        strings.Repeat("g", 100),
+		splitAddress: "0x" + strings.Repeat("1", 64),
+		expectedHash: "0x" + strings.Repeat("2", 64),
+		actualHash:   "0x" + strings.Repeat("3", 64),
+		wantTitle:    "[" + strings.Repeat("m", 100) + "] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: ` + strings.Repeat("m", 100) + `
 Group: ` + strings.Repeat("g", 100) + `
 Split Address: 0x` + strings.Repeat("1", 64) + `
 Expected Hash: 0x` + strings.Repeat("2", 64) + `
 Actual Hash: 0x` + strings.Repeat("3", 64),
-		},
-		{
-			name:         "unicode characters",
-			timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-			monitor:      "测试监控器",
-			group:        "测试组",
-			splitAddress: "0x测试地址",
-			expectedHash: "0x预期哈希",
-			actualHash:   "0x实际哈希",
-			wantTitle:    "[测试监控器] Split hash is in unknown state",
-			wantDesc: `
+	},
+	{
+		name:         "unicode characters",
+		timestamp:    time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		monitor:      "测试监控器",
+		group:        "测试组",
+		splitAddress: "0x测试地址",
+		expectedHash: "0x预期哈希",
+		actualHash:   "0x实际哈希",
+		wantTitle:    "[测试监控器] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 2024-01-01 12:00:00 UTC
 Monitor: 测试监控器
 Group: 测试组
 Split Address: 0x测试地址
 Expected Hash: 0x预期哈希
 Actual Hash: 0x实际哈希`,
-		},
-		{
-			name:         "edge timestamp",
-			timestamp:    time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
-			monitor:      "test_monitor",
-			group:        "test_group",
-			splitAddress: "0x123",
-			expectedHash: "0x456",
-			actualHash:   "0x789",
-			wantTitle:    "[test_monitor] Split hash is in unknown state",
-			wantDesc: `
+	},
+	{
+		name:         "edge timestamp",
+		timestamp:    time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
+		monitor:      "test_monitor",
+		group:        "test_group",
+		splitAddress: "0x123",
+		expectedHash: "0x456",
+		actualHash:   "0x789",
+		wantTitle:    "[test_monitor] Split hash is in unknown state",
+		wantDesc: `
 Timestamp: 9999-12-31 23:59:59 UTC
 Monitor: test_monitor
 Group: test_group
 Split Address: 0x123
 Expected Hash: 0x456
 Actual Hash: 0x789`,
-		},
-	}
+	},
+}
 
-	for _, tt := range tests {
+func TestHashUnknownState(t *testing.T) {
+	for _, tt := range hashUnknownStateTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			evt := split.NewHashUnknownState(
 				tt.timestamp,

--- a/pkg/monitor/event/validator/min_balance.go
+++ b/pkg/monitor/event/validator/min_balance.go
@@ -73,7 +73,7 @@ func (v *MinBalance) GetDescriptionText(includeMonitor, includeGroup bool) strin
 	sb.WriteString("\nPubkey: ")
 	sb.WriteString(v.Pubkey)
 	sb.WriteString("\nBalance: ")
-	sb.WriteString(fmt.Sprintf("%.4f ETH", float64(v.Balance)/1e18))
+	fmt.Fprintf(&sb, "%.4f ETH", float64(v.Balance)/1e18)
 
 	return sb.String()
 }
@@ -102,7 +102,7 @@ func (v *MinBalance) GetDescriptionMarkdown(includeMonitor, includeGroup bool) s
 	sb.WriteString("`\n")
 
 	sb.WriteString("**Balance:** ")
-	sb.WriteString(fmt.Sprintf("%.4f ETH", float64(v.Balance)/1e18))
+	fmt.Fprintf(&sb, "%.4f ETH", float64(v.Balance)/1e18)
 
 	return sb.String()
 }
@@ -131,7 +131,7 @@ func (v *MinBalance) GetDescriptionHTML(includeMonitor, includeGroup bool) strin
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Balance:</strong> ")
-	sb.WriteString(fmt.Sprintf("%.4f ETH", float64(v.Balance)/1e18))
+	fmt.Fprintf(&sb, "%.4f ETH", float64(v.Balance)/1e18)
 	sb.WriteString("</p>")
 
 	return sb.String()

--- a/pkg/monitor/event/validator/withdrawal_credentials.go
+++ b/pkg/monitor/event/validator/withdrawal_credentials.go
@@ -73,7 +73,7 @@ func (v *WithdrawalCredentials) GetDescriptionText(includeMonitor, includeGroup 
 	sb.WriteString("\nPubkey: ")
 	sb.WriteString(v.Pubkey)
 	sb.WriteString("\nCode: 0x")
-	sb.WriteString(fmt.Sprintf("%02x", v.Code))
+	fmt.Fprintf(&sb, "%02x", v.Code)
 
 	return sb.String()
 }
@@ -102,7 +102,7 @@ func (v *WithdrawalCredentials) GetDescriptionMarkdown(includeMonitor, includeGr
 	sb.WriteString("`\n")
 
 	sb.WriteString("**Code:** `0x")
-	sb.WriteString(fmt.Sprintf("%02x", v.Code))
+	fmt.Fprintf(&sb, "%02x", v.Code)
 	sb.WriteString("`")
 
 	return sb.String()
@@ -132,7 +132,7 @@ func (v *WithdrawalCredentials) GetDescriptionHTML(includeMonitor, includeGroup 
 	sb.WriteString("</p>")
 
 	sb.WriteString("<p><strong>Code:</strong> 0x")
-	sb.WriteString(fmt.Sprintf("%02x", v.Code))
+	fmt.Fprintf(&sb, "%02x", v.Code)
 	sb.WriteString("</p>")
 
 	return sb.String()

--- a/pkg/monitor/notifier/publisher.go
+++ b/pkg/monitor/notifier/publisher.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -57,11 +58,11 @@ func (p *Publisher) Publish(e event.Event) error {
 
 func (p *Publisher) PublishWithContext(ctx context.Context, e event.Event) error {
 	if e == nil {
-		return fmt.Errorf("cannot publish nil event")
+		return errors.New("cannot publish nil event")
 	}
 
 	if ctx == nil {
-		return fmt.Errorf("cannot publish with nil context")
+		return errors.New("cannot publish with nil context")
 	}
 
 	// Create a reasonable timeout for publishing events

--- a/pkg/monitor/notifier/publisher_test.go
+++ b/pkg/monitor/notifier/publisher_test.go
@@ -2,7 +2,7 @@ package notifier
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockEvent implements the event.Event interface for testing.
@@ -107,7 +108,7 @@ func TestPublisherNilChecks(t *testing.T) {
 
 	// Test nil event
 	err := publisher.Publish(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot publish nil event")
 
 	// Test nil context using PublishWithContext
@@ -115,7 +116,7 @@ func TestPublisherNilChecks(t *testing.T) {
 	mockEvent.On("GetGroup").Return("test-group")
 	//nolint:staticcheck // Testing nil context handling
 	err = publisher.PublishWithContext(nil, mockEvent)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot publish with nil context")
 }
 
@@ -147,7 +148,7 @@ func TestPublisherSourceGroupFiltering(t *testing.T) {
 
 	// The event should be filtered out based on group
 	err := publisher.Publish(mockEvent)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockSource.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
 
 	// Create publisher with a source that has a matching group filter
@@ -164,7 +165,7 @@ func TestPublisherSourceGroupFiltering(t *testing.T) {
 
 	// The event should be published
 	err = publisher.Publish(mockEvent)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockSource.AssertCalled(t, "Publish", mock.Anything, mockEvent)
 }
 
@@ -190,7 +191,7 @@ func TestPublisherNilSource(t *testing.T) {
 
 	// The nil source should be skipped without error
 	err := publisher.Publish(mockEvent)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestPublisherContextCancellation(t *testing.T) {
@@ -226,7 +227,7 @@ func TestPublisherContextCancellation(t *testing.T) {
 
 	// The publish operation should fail due to context cancellation
 	err := publisher.PublishWithContext(ctx, mockEvent)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context cancelled")
 }
 
@@ -239,7 +240,7 @@ func TestPublisherSourceError(t *testing.T) {
 	mockSource := new(MockSource)
 	mockSource.On("GetName").Return("error-source")
 
-	expectedErr := fmt.Errorf("publish error")
+	expectedErr := errors.New("publish error")
 	mockSource.On("Publish", mock.Anything, mock.Anything).Return(expectedErr)
 
 	// Setup mock event
@@ -259,7 +260,7 @@ func TestPublisherSourceError(t *testing.T) {
 
 	// The publish operation should return the source error
 	err := publisher.Publish(mockEvent)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error publishing to source")
 }
 
@@ -299,13 +300,13 @@ func TestPublisherStartStop(t *testing.T) {
 	// Test Start
 	ctx := context.Background()
 	err := publisher.Start(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockSourceA.AssertCalled(t, "Start", ctx)
 	mockSourceB.AssertCalled(t, "Start", ctx)
 
 	// Test Stop
 	err = publisher.Stop(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockSourceA.AssertCalled(t, "Stop", ctx)
 	mockSourceB.AssertCalled(t, "Stop", ctx)
 }
@@ -317,7 +318,7 @@ func TestPublisherStartError(t *testing.T) {
 
 	// Create mock source that returns an error on Start
 	mockSource := new(MockSource)
-	expectedErr := fmt.Errorf("start error")
+	expectedErr := errors.New("start error")
 	mockSource.On("Start", mock.Anything).Return(expectedErr)
 
 	// Create publisher with the error-returning source
@@ -334,7 +335,7 @@ func TestPublisherStartError(t *testing.T) {
 	// The Start operation should return the source error
 	ctx := context.Background()
 	err := publisher.Start(ctx)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 }
 
@@ -347,7 +348,7 @@ func TestPublisherStopError(t *testing.T) {
 	mockSource := new(MockSource)
 	mockSource.On("Start", mock.Anything).Return(nil)
 
-	expectedErr := fmt.Errorf("stop error")
+	expectedErr := errors.New("stop error")
 	mockSource.On("Stop", mock.Anything).Return(expectedErr)
 
 	// Create publisher with the error-returning source
@@ -364,10 +365,10 @@ func TestPublisherStopError(t *testing.T) {
 	// Start should succeed
 	ctx := context.Background()
 	err := publisher.Start(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// The Stop operation should return the source error
 	err = publisher.Stop(ctx)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 }

--- a/pkg/monitor/notifier/raw_message.go
+++ b/pkg/monitor/notifier/raw_message.go
@@ -1,15 +1,15 @@
 package notifier
 
 type RawMessage struct {
-	unmarshal func(interface{}) error
+	unmarshal func(any) error
 }
 
-func (r *RawMessage) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *RawMessage) UnmarshalYAML(unmarshal func(any) error) error {
 	r.unmarshal = unmarshal
 
 	return nil
 }
 
-func (r *RawMessage) Unmarshal(v interface{}) error {
+func (r *RawMessage) Unmarshal(v any) error {
 	return r.unmarshal(v)
 }

--- a/pkg/monitor/notifier/raw_message_test.go
+++ b/pkg/monitor/notifier/raw_message_test.go
@@ -1,10 +1,11 @@
 package notifier
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This test is for raw_message.go which is imported from the same package
@@ -34,7 +35,7 @@ func TestRawMessageUnmarshal(t *testing.T) {
 				return nil
 			}
 
-			return fmt.Errorf("unsupported type")
+			return errors.New("unsupported type")
 		},
 	}
 
@@ -42,7 +43,7 @@ func TestRawMessageUnmarshal(t *testing.T) {
 	var result TestStruct
 
 	err := rawMsg.Unmarshal(&result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify the result
 	assert.Equal(t, testStruct.Name, result.Name)
@@ -53,7 +54,7 @@ func TestRawMessageUnmarshalError(t *testing.T) {
 	// Create a RawMessage with error-returning unmarshal function
 	rawMsg := &RawMessage{
 		unmarshal: func(v any) error {
-			return fmt.Errorf("mock unmarshal error")
+			return errors.New("mock unmarshal error")
 		},
 	}
 
@@ -61,7 +62,7 @@ func TestRawMessageUnmarshalError(t *testing.T) {
 	var result TestStruct
 
 	err := rawMsg.Unmarshal(&result)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mock unmarshal error")
 }
 
@@ -94,7 +95,7 @@ func TestRawMessageYAMLUnmarshal(t *testing.T) {
 
 	// Call UnmarshalYAML
 	err := rawMsg.UnmarshalYAML(mockUnmarshal)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify the unmarshal function was set
 	assert.NotNil(t, rawMsg.unmarshal)
@@ -103,6 +104,6 @@ func TestRawMessageYAMLUnmarshal(t *testing.T) {
 	var result TestStruct
 
 	err = rawMsg.Unmarshal(&result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, called, "The unmarshal function should have been called")
 }

--- a/pkg/monitor/notifier/source/discord/discord.go
+++ b/pkg/monitor/notifier/source/discord/discord.go
@@ -82,11 +82,11 @@ func (c *Discord) Publish(ctx context.Context, e event.Event) error {
 		description = fmt.Sprintf("%s\n\n[**Go to docs**](%s)", description, docURL)
 	}
 
-	message := map[string]interface{}{
+	message := map[string]any{
 		"username": "Splitoor",
-		"embeds": []map[string]interface{}{
+		"embeds": []map[string]any{
 			{
-				"title":       fmt.Sprintf("🚨 %s", e.GetTitle(c.includeMonitorName, c.includeGroupName)),
+				"title":       "🚨 " + e.GetTitle(c.includeMonitorName, c.includeGroupName),
 				"description": description,
 				"color":       16711680,
 			},
@@ -100,7 +100,7 @@ func (c *Discord) Publish(ctx context.Context, e event.Event) error {
 		return fmt.Errorf("failed to marshal discord message: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.config.Webhook, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.config.Webhook, bytes.NewBuffer(jsonData))
 	if err != nil {
 		errorType = "request_error"
 

--- a/pkg/monitor/notifier/source/discord/discord_test.go
+++ b/pkg/monitor/notifier/source/discord/discord_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockEvent struct {
@@ -82,10 +83,10 @@ func TestNewDiscord(t *testing.T) {
 			discord, err := disc.NewDiscord(context.Background(), entry, tt.monitor, tt.name, nil, true, true, tt.config)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, discord)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, discord)
 				assert.Equal(t, tt.name, discord.GetName())
 				assert.Equal(t, tt.config.Webhook, discord.GetConfig().Webhook)
@@ -131,7 +132,7 @@ func TestDiscordPublish(t *testing.T) {
 			discord, err := disc.NewDiscord(context.Background(), entry, "test", "test_source", nil, true, true, &disc.Config{
 				Webhook: server.URL,
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			mockEvent := new(MockEvent)
 			mockEvent.On("GetGroup").Return("test_group")
@@ -141,9 +142,9 @@ func TestDiscordPublish(t *testing.T) {
 			err = discord.Publish(context.Background(), mockEvent)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			mockEvent.AssertExpectations(t)
@@ -157,13 +158,13 @@ func TestDiscordStartStop(t *testing.T) {
 	discord, err := disc.NewDiscord(context.Background(), entry, "test", "test_source", nil, true, true, &disc.Config{
 		Webhook: "https://discord.com/api/webhooks/test",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = discord.Start(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = discord.Stop(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDiscordGetTypeAndName(t *testing.T) {
@@ -172,7 +173,7 @@ func TestDiscordGetTypeAndName(t *testing.T) {
 	discord, err := disc.NewDiscord(context.Background(), entry, "test", "test_source", nil, true, true, &disc.Config{
 		Webhook: "https://discord.com/api/webhooks/test",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, disc.SourceType, discord.GetType())
 	assert.Equal(t, "test_source", discord.GetName())

--- a/pkg/monitor/notifier/source/raw_message.go
+++ b/pkg/monitor/notifier/source/raw_message.go
@@ -1,15 +1,15 @@
 package source
 
 type RawMessage struct {
-	unmarshal func(interface{}) error
+	unmarshal func(any) error
 }
 
-func (r *RawMessage) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *RawMessage) UnmarshalYAML(unmarshal func(any) error) error {
 	r.unmarshal = unmarshal
 
 	return nil
 }
 
-func (r *RawMessage) Unmarshal(v interface{}) error {
+func (r *RawMessage) Unmarshal(v any) error {
 	return r.unmarshal(v)
 }

--- a/pkg/monitor/notifier/source/ses/config.go
+++ b/pkg/monitor/notifier/source/ses/config.go
@@ -1,6 +1,6 @@
 package ses
 
-import "fmt"
+import "errors"
 
 type Config struct {
 	From string   `yaml:"from"`
@@ -9,11 +9,11 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c.From == "" {
-		return fmt.Errorf("from is required")
+		return errors.New("from is required")
 	}
 
 	if len(c.To) == 0 {
-		return fmt.Errorf("to is required")
+		return errors.New("to is required")
 	}
 
 	return nil

--- a/pkg/monitor/notifier/source/ses/ses.go
+++ b/pkg/monitor/notifier/source/ses/ses.go
@@ -2,6 +2,7 @@ package ses
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -30,7 +31,7 @@ type SES struct {
 
 func NewSES(ctx context.Context, log logrus.FieldLogger, monitor, name string, docs *string, includeMonitorName, includeGroupName bool, config *Config) (*SES, error) {
 	if config == nil {
-		return nil, fmt.Errorf("config is required")
+		return nil, errors.New("config is required")
 	}
 
 	sess, err := session.NewSession(&aws.Config{})
@@ -96,21 +97,22 @@ func (s *SES) Publish(ctx context.Context, e event.Event) error {
 		Message: &ses.Message{
 			Body: &ses.Body{
 				Text: &ses.Content{
-					Charset: aws.String("UTF-8"),
-					Data:    aws.String(description),
+					Charset: new("UTF-8"),
+					Data:    new(description),
 				},
 			},
 			Subject: &ses.Content{
-				Charset: aws.String("UTF-8"),
-				Data:    aws.String(fmt.Sprintf("🚨 %s", e.GetTitle(s.includeMonitorName, s.includeGroupName))),
+				Charset: new("UTF-8"),
+				Data:    new("🚨 " + e.GetTitle(s.includeMonitorName, s.includeGroupName)),
 			},
 		},
-		Source: aws.String(s.config.From),
+		Source: new(s.config.From),
 	}
 
 	_, err := s.client.SendEmailWithContext(ctx, input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
+		var aerr awserr.Error
+		if errors.As(err, &aerr) {
 			switch aerr.Code() {
 			case ses.ErrCodeMessageRejected:
 				errorType = "message_rejected"

--- a/pkg/monitor/notifier/source/ses/ses_test.go
+++ b/pkg/monitor/notifier/source/ses/ses_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockEvent struct {
@@ -75,10 +76,10 @@ func TestNewSES(t *testing.T) {
 			ses, err := s.NewSES(context.Background(), entry, tt.monitor, tt.name, nil, true, true, tt.config)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, ses)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, ses)
 				assert.Equal(t, tt.name, ses.GetName())
 				assert.Equal(t, tt.config, ses.GetConfig())
@@ -94,13 +95,13 @@ func TestSESStartStop(t *testing.T) {
 		From: "test@example.com",
 		To:   []string{"recipient@example.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = ses.Start(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = ses.Stop(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSESGetTypeAndName(t *testing.T) {
@@ -110,7 +111,7 @@ func TestSESGetTypeAndName(t *testing.T) {
 		From: "test@example.com",
 		To:   []string{"recipient@example.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, s.SourceType, ses.GetType())
 	assert.Equal(t, "test_source", ses.GetName())

--- a/pkg/monitor/notifier/source/smtp/email.go
+++ b/pkg/monitor/notifier/source/smtp/email.go
@@ -77,7 +77,7 @@ func (s *SMTP) Publish(ctx context.Context, evt event.Event) error {
 		description = fmt.Sprintf("%s\n\nGo to docs: %s", description, docURL)
 	}
 
-	if err := s.sendEmail(evt, fmt.Sprintf("🚨 %s", evt.GetTitle(s.includeMonitorName, s.includeGroupName)), description); err != nil {
+	if err := s.sendEmail(evt, "🚨 "+evt.GetTitle(s.includeMonitorName, s.includeGroupName), description); err != nil {
 		return err
 	}
 
@@ -105,73 +105,69 @@ func (s *SMTP) sendEmail(evt event.Event, subject, body string) error {
 
 	s.log.WithField("tls", s.config.TLS).Info("Sending email")
 
-	if s.config.TLS {
-		tlsConfig := &tls.Config{
-			ServerName: s.config.Host,
-			MinVersion: tls.VersionTLS12,
-			//nolint:gosec // InsecureSkipVerify is configurable by the user
-			InsecureSkipVerify: s.config.InsecureSkipVerify,
-		}
+	if !s.config.TLS {
+		if err := smtp.SendMail(addr, s.smtpAuth, s.config.From, s.config.To, []byte(msg)); err != nil {
+			errorType = "send_error"
 
-		client, err := smtp.Dial(addr)
-		if err != nil {
-			errorType = "dial_error"
-
-			return fmt.Errorf("failed to dial SMTP server: %w", err)
-		}
-		defer client.Close()
-
-		if tlsErr := client.StartTLS(tlsConfig); tlsErr != nil {
-			errorType = "tls_error"
-
-			return fmt.Errorf("failed to start TLS: %w", tlsErr)
-		}
-
-		if s.smtpAuth != nil {
-			if authErr := client.Auth(s.smtpAuth); authErr != nil {
-				errorType = "auth_error"
-
-				return fmt.Errorf("failed to authenticate: %w", authErr)
-			}
-		}
-
-		if mailErr := client.Mail(s.config.From); mailErr != nil {
-			errorType = "sender_error"
-
-			return fmt.Errorf("failed to set sender: %w", mailErr)
-		}
-
-		for _, to := range s.config.To {
-			if rcptErr := client.Rcpt(to); rcptErr != nil {
-				errorType = "recipient_error"
-
-				return fmt.Errorf("failed to add recipient %s: %w", to, rcptErr)
-			}
-		}
-
-		w, err := client.Data()
-		if err != nil {
-			errorType = "data_error"
-
-			return fmt.Errorf("failed to create message writer: %w", err)
-		}
-		defer w.Close()
-
-		_, err = w.Write([]byte(msg))
-		if err != nil {
-			errorType = "write_error"
-
-			return fmt.Errorf("failed to write message: %w", err)
+			return fmt.Errorf("failed to send email: %w", err)
 		}
 
 		return nil
 	}
 
-	if err := smtp.SendMail(addr, s.smtpAuth, s.config.From, s.config.To, []byte(msg)); err != nil {
-		errorType = "send_error"
+	errType, sendErr := s.sendTLSEmail(addr, msg)
+	if sendErr != nil {
+		errorType = errType
 
-		return fmt.Errorf("failed to send email: %w", err)
+		return sendErr
 	}
 
 	return nil
+}
+
+func (s *SMTP) sendTLSEmail(addr, msg string) (string, error) {
+	tlsConfig := &tls.Config{
+		ServerName: s.config.Host,
+		MinVersion: tls.VersionTLS12,
+		//nolint:gosec // InsecureSkipVerify is configurable by the user
+		InsecureSkipVerify: s.config.InsecureSkipVerify,
+	}
+
+	client, err := smtp.Dial(addr)
+	if err != nil {
+		return "dial_error", fmt.Errorf("failed to dial SMTP server: %w", err)
+	}
+	defer client.Close()
+
+	if tlsErr := client.StartTLS(tlsConfig); tlsErr != nil {
+		return "tls_error", fmt.Errorf("failed to start TLS: %w", tlsErr)
+	}
+
+	if s.smtpAuth != nil {
+		if authErr := client.Auth(s.smtpAuth); authErr != nil {
+			return "auth_error", fmt.Errorf("failed to authenticate: %w", authErr)
+		}
+	}
+
+	if mailErr := client.Mail(s.config.From); mailErr != nil {
+		return "sender_error", fmt.Errorf("failed to set sender: %w", mailErr)
+	}
+
+	for _, to := range s.config.To {
+		if rcptErr := client.Rcpt(to); rcptErr != nil {
+			return "recipient_error", fmt.Errorf("failed to add recipient %s: %w", to, rcptErr)
+		}
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return "data_error", fmt.Errorf("failed to create message writer: %w", err)
+	}
+	defer w.Close()
+
+	if _, writeErr := w.Write([]byte(msg)); writeErr != nil {
+		return "write_error", fmt.Errorf("failed to write message: %w", writeErr)
+	}
+
+	return "", nil
 }

--- a/pkg/monitor/notifier/source/smtp/smtp_test.go
+++ b/pkg/monitor/notifier/source/smtp/smtp_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockEvent struct {
@@ -79,10 +80,10 @@ func TestNewSMTP(t *testing.T) {
 			smtp, err := email.NewSMTP(context.Background(), entry, tt.monitor, tt.name, nil, true, true, tt.config)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, smtp)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, smtp)
 				assert.Equal(t, tt.name, smtp.GetName())
 				assert.Equal(t, tt.config, smtp.GetConfig())
@@ -102,13 +103,13 @@ func TestSMTPStartStop(t *testing.T) {
 		From:     "test@example.com",
 		To:       []string{"recipient@example.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = smtp.Start(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = smtp.Stop(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSMTPGetTypeAndName(t *testing.T) {
@@ -122,7 +123,7 @@ func TestSMTPGetTypeAndName(t *testing.T) {
 		From:     "test@example.com",
 		To:       []string{"recipient@example.com"},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, email.SourceType, smtp.GetType())
 	assert.Equal(t, "test_source", smtp.GetName())

--- a/pkg/monitor/notifier/source/source.go
+++ b/pkg/monitor/notifier/source/source.go
@@ -22,80 +22,54 @@ type Source interface {
 	Publish(ctx context.Context, e event.Event) error
 }
 
+type configValidator interface {
+	Validate() error
+}
+
+func initConfig[T configValidator](config *RawMessage, conf T) error {
+	if config != nil {
+		if err := config.Unmarshal(conf); err != nil {
+			return err
+		}
+	}
+
+	if err := defaults.Set(conf); err != nil {
+		return err
+	}
+
+	return conf.Validate()
+}
+
 func NewSource(ctx context.Context, log logrus.FieldLogger, monitor, sourceName string, docs *string, sourceType SourceType, includeMonitorName, includeGroupName bool, config *RawMessage) (Source, error) {
 	if sourceType == SourceTypeUnknown {
 		return nil, errors.New("source type is required")
 	}
 
-	switch sourceType {
+	switch sourceType { //nolint:exhaustive // SourceTypeUnknown is handled above
 	case SourceTypeDiscord:
 		conf := &discord.Config{}
-
-		if config != nil {
-			if err := config.Unmarshal(conf); err != nil {
-				return nil, err
-			}
-		}
-
-		if err := defaults.Set(conf); err != nil {
-			return nil, err
-		}
-
-		if err := conf.Validate(); err != nil {
+		if err := initConfig(config, conf); err != nil {
 			return nil, err
 		}
 
 		return discord.NewDiscord(ctx, log, monitor, sourceName, docs, includeMonitorName, includeGroupName, conf)
 	case SourceTypeSMTP:
 		conf := &smtp.Config{}
-
-		if config != nil {
-			if err := config.Unmarshal(conf); err != nil {
-				return nil, err
-			}
-		}
-
-		if err := defaults.Set(conf); err != nil {
-			return nil, err
-		}
-
-		if err := conf.Validate(); err != nil {
+		if err := initConfig(config, conf); err != nil {
 			return nil, err
 		}
 
 		return smtp.NewSMTP(ctx, log, monitor, sourceName, docs, includeMonitorName, includeGroupName, conf)
 	case SourceTypeSES:
 		conf := &ses.Config{}
-
-		if config != nil {
-			if err := config.Unmarshal(conf); err != nil {
-				return nil, err
-			}
-		}
-
-		if err := defaults.Set(conf); err != nil {
-			return nil, err
-		}
-
-		if err := conf.Validate(); err != nil {
+		if err := initConfig(config, conf); err != nil {
 			return nil, err
 		}
 
 		return ses.NewSES(ctx, log, monitor, sourceName, docs, includeMonitorName, includeGroupName, conf)
 	case SourceTypeTelegram:
 		conf := &telegram.Config{}
-
-		if config != nil {
-			if err := config.Unmarshal(conf); err != nil {
-				return nil, err
-			}
-		}
-
-		if err := defaults.Set(conf); err != nil {
-			return nil, err
-		}
-
-		if err := conf.Validate(); err != nil {
+		if err := initConfig(config, conf); err != nil {
 			return nil, err
 		}
 

--- a/pkg/monitor/notifier/source/source_test.go
+++ b/pkg/monitor/notifier/source/source_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -26,7 +27,7 @@ func TestNewSourceInvalidType(t *testing.T) {
 
 	// Should return error for unknown source type
 	_, err := NewSource(ctx, log, testMonitorName, testSourceName, nil, sourceType, includeMonitorName, includeGroupName, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source type is required")
 }
 
@@ -42,7 +43,7 @@ func TestNewSourceUnsupportedType(t *testing.T) {
 
 	// Should return error for unsupported source type
 	_, err := NewSource(ctx, log, testMonitorName, testSourceName, nil, sourceType, includeMonitorName, includeGroupName, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "source type is not supported")
 }
 
@@ -65,7 +66,7 @@ func TestNewSourceConfigUnmarshalError(t *testing.T) {
 
 	// Should return error when config can't be unmarshalled
 	_, err := NewSource(ctx, log, testMonitorName, testSourceName, nil, sourceType, includeMonitorName, includeGroupName, mockRawMsg)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mock unmarshal error")
 }
 
@@ -77,7 +78,7 @@ func TestConfigValidate(t *testing.T) {
 		Name:       "test",
 	}
 	err := config.Validate()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "notifier source type is required")
 
 	// Test with valid source type
@@ -86,7 +87,7 @@ func TestConfigValidate(t *testing.T) {
 		Name:       "test",
 	}
 	err = config.Validate()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // Test RawMessage.
@@ -104,7 +105,7 @@ func TestRawMessageUnmarshal(t *testing.T) {
 
 	// Call Unmarshal
 	err := rawMsg.Unmarshal(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, called, "Unmarshal function should have been called")
 
 	// Test with a failing unmarshal function
@@ -116,7 +117,7 @@ func TestRawMessageUnmarshal(t *testing.T) {
 	}
 
 	err = rawMsg.Unmarshal(nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 }
 
@@ -131,14 +132,14 @@ func TestRawMessageUnmarshalYAML(t *testing.T) {
 
 	// Call UnmarshalYAML
 	err := rawMsg.UnmarshalYAML(mockUnmarshal)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify that the unmarshal function was set
 	assert.NotNil(t, rawMsg.unmarshal)
 
 	// Call Unmarshal to verify it uses the set function
 	err = rawMsg.Unmarshal(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRawMessageNilUnmarshal(t *testing.T) {

--- a/pkg/monitor/notifier/source/telegram/telegram_test.go
+++ b/pkg/monitor/notifier/source/telegram/telegram_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const SourceType = "telegram"
@@ -112,7 +113,7 @@ func TestNewTelegram(t *testing.T) {
 
 			if tt.expectError {
 				telegram, err := tel.NewTelegram(context.Background(), entry.WithField("source", "telegram"), tt.monitor, tt.name, nil, true, true, tt.config)
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, telegram)
 
 				return
@@ -120,7 +121,7 @@ func TestNewTelegram(t *testing.T) {
 
 			mockBot := setupMockBot()
 			telegram, err := tel.NewTelegramWithClient(entry.WithField("source", "telegram"), tt.monitor, tt.name, nil, true, true, tt.config, mockBot)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, telegram)
 			assert.Equal(t, tt.name, telegram.GetName())
 			assert.NotNil(t, telegram.GetConfig())
@@ -158,11 +159,11 @@ func TestTelegramPublish(t *testing.T) {
 		BotToken: "test-token",
 		ChatID:   "123456789",
 	}, mockBot)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test Publish
 	err = telegram.Publish(context.Background(), mockEvent)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockBot.AssertExpectations(t)
 	mockEvent.AssertExpectations(t)
@@ -177,13 +178,13 @@ func TestTelegramStartStop(t *testing.T) {
 		BotToken: "test-token",
 		ChatID:   "123456789",
 	}, mockBot)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = telegram.Start(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = telegram.Stop(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestTelegramGetTypeAndName(t *testing.T) {
@@ -195,7 +196,7 @@ func TestTelegramGetTypeAndName(t *testing.T) {
 		BotToken: "test-token",
 		ChatID:   "123456789",
 	}, mockBot)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, SourceType, telegram.GetType())
 	assert.Equal(t, "test_source", telegram.GetName())

--- a/pkg/monitor/safe/client.go
+++ b/pkg/monitor/safe/client.go
@@ -3,6 +3,7 @@ package safe
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -25,6 +26,8 @@ type Client interface {
 	SetChain(chain string)
 }
 
+const maxRateLimitRetries = 5
+
 type client struct {
 	log     logrus.FieldLogger
 	baseURL string
@@ -33,8 +36,10 @@ type client struct {
 	metrics *Metrics
 	limiter *rate.Limiter
 
-	baseRate rate.Limit // Store original rate for restoration after 429
-	rateMu   sync.Mutex // Protect rate adjustments
+	baseRate       rate.Limit    // Store original rate for restoration after 429
+	rateMu         sync.Mutex    // Protect rate adjustments and backoff state
+	rateLimitCh    chan struct{} // Non-nil when rate limited; closed when restored
+	rateLimitCount int           // Consecutive rate limit pauses for exponential backoff
 
 	chain   string
 	chainMu sync.Mutex
@@ -69,8 +74,20 @@ func (c *client) SetChain(chain string) {
 }
 
 // handleRateLimitResponse pauses the rate limiter and returns a channel that closes
-// when the rate limiter is restored. This allows the caller to wait for restoration.
+// when the rate limiter is restored. If already rate limited, returns the existing
+// channel so multiple goroutines coalesce on the same pause window. Consecutive
+// rate limits apply exponential backoff to the delay and reduce the restore rate.
 func (c *client) handleRateLimitResponse(resp *http.Response) <-chan struct{} {
+	c.rateMu.Lock()
+	defer c.rateMu.Unlock()
+
+	// Already rate limited, return existing channel.
+	if c.rateLimitCh != nil {
+		return c.rateLimitCh
+	}
+
+	c.rateLimitCount++
+
 	delay := 5 * time.Second
 
 	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
@@ -79,27 +96,55 @@ func (c *client) handleRateLimitResponse(resp *http.Response) <-chan struct{} {
 		}
 	}
 
-	c.log.WithField("delay", delay).Warn("rate limited by Safe API, pausing requests")
+	// Exponential backoff: double the delay for each consecutive rate limit, cap at 4x.
+	if c.rateLimitCount > 1 {
+		shift := min(c.rateLimitCount-1, 2)
+		delay *= time.Duration(1 << shift)
+	}
 
-	c.rateMu.Lock()
+	// Reduce restore rate for consecutive rate limits: halve each time, cap at 1/4.
+	shift := min(c.rateLimitCount-1, 2)
+	restoreRate := c.baseRate / rate.Limit(int(1)<<shift)
+
+	c.log.WithFields(logrus.Fields{
+		"delay":       delay,
+		"consecutive": c.rateLimitCount,
+		"restore_rps": float64(restoreRate),
+	}).Warn("rate limited by Safe API, pausing requests")
+
 	c.limiter.SetLimit(0)
-	c.rateMu.Unlock()
 
 	restored := make(chan struct{})
+	c.rateLimitCh = restored
 
 	go func() {
 		time.Sleep(delay)
 
 		c.rateMu.Lock()
-		c.limiter.SetLimit(c.baseRate)
+		c.limiter.SetLimit(restoreRate)
+		c.rateLimitCh = nil
 		c.rateMu.Unlock()
 
-		c.log.Info("rate limiter restored")
+		c.log.WithField("rps", float64(restoreRate)).Info("rate limiter restored")
 
 		close(restored)
 	}()
 
 	return restored
+}
+
+// resetRateLimitBackoff resets the consecutive rate limit counter and restores
+// the base rate after a successful (non-429) response.
+func (c *client) resetRateLimitBackoff() {
+	c.rateMu.Lock()
+	defer c.rateMu.Unlock()
+
+	if c.rateLimitCount == 0 {
+		return
+	}
+
+	c.rateLimitCount = 0
+	c.limiter.SetLimit(c.baseRate)
 }
 
 // getChain returns the current chain or an error if not set.
@@ -108,7 +153,7 @@ func (c *client) getChain() (string, error) {
 	defer c.chainMu.Unlock()
 
 	if c.chain == "" {
-		return "", fmt.Errorf("chain is not set")
+		return "", errors.New("chain is not set")
 	}
 
 	return c.chain, nil
@@ -143,7 +188,7 @@ func (c *client) GetQueuedTransactions(
 			minNonce,
 		)
 
-		req, reqErr := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 		if reqErr != nil {
 			return nil, start, fmt.Errorf("failed to create request: %w", reqErr)
 		}
@@ -165,8 +210,8 @@ func (c *client) GetQueuedTransactions(
 		return nil, err
 	}
 
-	// Handle 429 rate limit response with retry
-	if resp.StatusCode == http.StatusTooManyRequests {
+	// Handle 429 rate limit responses with retry loop.
+	for attempt := 0; resp.StatusCode == http.StatusTooManyRequests && attempt < maxRateLimitRetries; attempt++ {
 		restored := c.handleRateLimitResponse(resp)
 		resp.Body.Close()
 
@@ -194,13 +239,19 @@ func (c *client) GetQueuedTransactions(
 		time.Since(start),
 	)
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("rate limit retries exhausted after %d attempts", maxRateLimitRetries)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
+	c.resetRateLimitBackoff()
+
 	var result MultisigTransactionsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&result); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", decodeErr)
 	}
 
 	return &result, nil
@@ -233,7 +284,7 @@ func (c *client) GetTransaction(
 			safeTxHash,
 		)
 
-		req, reqErr := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 		if reqErr != nil {
 			return nil, start, fmt.Errorf("failed to create request: %w", reqErr)
 		}
@@ -255,8 +306,8 @@ func (c *client) GetTransaction(
 		return nil, err
 	}
 
-	// Handle 429 rate limit response with retry
-	if resp.StatusCode == http.StatusTooManyRequests {
+	// Handle 429 rate limit responses with retry loop.
+	for attempt := 0; resp.StatusCode == http.StatusTooManyRequests && attempt < maxRateLimitRetries; attempt++ {
 		restored := c.handleRateLimitResponse(resp)
 		resp.Body.Close()
 
@@ -284,13 +335,19 @@ func (c *client) GetTransaction(
 		time.Since(start),
 	)
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("rate limit retries exhausted after %d attempts", maxRateLimitRetries)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
+	c.resetRateLimitBackoff()
+
 	var result MultisigTransaction
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&result); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", decodeErr)
 	}
 
 	return &result, nil
@@ -320,7 +377,7 @@ func (c *client) GetSafe(ctx context.Context, safeAddress string) (*SafeResponse
 			safeAddress,
 		)
 
-		req, reqErr := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 		if reqErr != nil {
 			return nil, start, fmt.Errorf("failed to create request: %w", reqErr)
 		}
@@ -342,8 +399,8 @@ func (c *client) GetSafe(ctx context.Context, safeAddress string) (*SafeResponse
 		return nil, err
 	}
 
-	// Handle 429 rate limit response with retry
-	if resp.StatusCode == http.StatusTooManyRequests {
+	// Handle 429 rate limit responses with retry loop.
+	for attempt := 0; resp.StatusCode == http.StatusTooManyRequests && attempt < maxRateLimitRetries; attempt++ {
 		restored := c.handleRateLimitResponse(resp)
 		resp.Body.Close()
 
@@ -371,13 +428,19 @@ func (c *client) GetSafe(ctx context.Context, safeAddress string) (*SafeResponse
 		time.Since(start),
 	)
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("rate limit retries exhausted after %d attempts", maxRateLimitRetries)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
+	c.resetRateLimitBackoff()
+
 	var result SafeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&result); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", decodeErr)
 	}
 
 	return &result, nil

--- a/pkg/monitor/safe/client_test.go
+++ b/pkg/monitor/safe/client_test.go
@@ -102,8 +102,11 @@ func TestClient_GetQueuedTransactions(t *testing.T) {
 				w.WriteHeader(tt.serverStatus)
 
 				if tt.serverResponse != nil {
-					err := json.NewEncoder(w).Encode(tt.serverResponse)
-					require.NoError(t, err)
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+
+						return
+					}
 				}
 			}))
 			defer server.Close()
@@ -120,7 +123,7 @@ func TestClient_GetQueuedTransactions(t *testing.T) {
 
 			resp, err := c.GetQueuedTransactions(context.Background(), tt.safeAddress, 0)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 
 				return
 			}
@@ -189,8 +192,11 @@ func TestClient_GetTransaction(t *testing.T) {
 				w.WriteHeader(tt.serverStatus)
 
 				if tt.serverResponse != nil {
-					err := json.NewEncoder(w).Encode(tt.serverResponse)
-					require.NoError(t, err)
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+
+						return
+					}
 				}
 			}))
 			defer server.Close()
@@ -207,7 +213,7 @@ func TestClient_GetTransaction(t *testing.T) {
 
 			tx, err := c.GetTransaction(context.Background(), tt.safeTxHash)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 
 				return
 			}
@@ -230,7 +236,7 @@ func TestClient_SetChain(t *testing.T) {
 	// Test concurrent chain updates
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 
 		fn := func(id int) {
@@ -251,7 +257,7 @@ func TestClient_SetChain(t *testing.T) {
 	defer cancel()
 
 	_, err = c.GetQueuedTransactions(ctx, "0x123", 0)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestClient_URLConstruction(t *testing.T) {
@@ -264,8 +270,11 @@ func TestClient_URLConstruction(t *testing.T) {
 		assert.Equal(t, expectedPath, r.URL.Path)
 		assert.Equal(t, fmt.Sprintf("executed=false&nonce__gte=%d", minNonce), r.URL.RawQuery)
 
-		err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{})
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -308,8 +317,12 @@ func TestClient_RequestMetrics(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, tt.path, r.URL.Path)
 				w.WriteHeader(tt.statusCode)
-				err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{})
-				require.NoError(t, err)
+
+				if err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+
+					return
+				}
 			}))
 			defer server.Close()
 
@@ -318,9 +331,9 @@ func TestClient_RequestMetrics(t *testing.T) {
 
 			_, err := c.GetQueuedTransactions(context.Background(), "0x123", 0)
 			if tt.shouldError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -354,8 +367,11 @@ func TestClient_InvalidResponses(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 
-				_, err := w.Write([]byte(tt.response))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(tt.response)); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+
+					return
+				}
 			}))
 			defer server.Close()
 
@@ -364,9 +380,9 @@ func TestClient_InvalidResponses(t *testing.T) {
 
 			_, err := c.GetQueuedTransactions(context.Background(), "0x123", 0)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -387,15 +403,19 @@ func TestClient_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	_, err := c.GetQueuedTransactions(ctx, "0x123", 0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
 }
 
 func TestClient_ParallelRequests(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{})
-		require.NoError(t, err)
+
+		if err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -404,14 +424,14 @@ func TestClient_ParallelRequests(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 
 		fn := func() {
 			defer wg.Done()
 
 			_, err := c.GetQueuedTransactions(context.Background(), "0x123", 0)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 
 		go fn()
@@ -472,8 +492,11 @@ func TestClient_GetSafe(t *testing.T) {
 				w.WriteHeader(tt.serverStatus)
 
 				if tt.serverResponse != nil {
-					err := json.NewEncoder(w).Encode(tt.serverResponse)
-					require.NoError(t, err)
+					if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+
+						return
+					}
 				}
 			}))
 			defer server.Close()
@@ -490,7 +513,7 @@ func TestClient_GetSafe(t *testing.T) {
 
 			resp, err := c.GetSafe(context.Background(), tt.safeAddress)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 
 				return
 			}
@@ -499,7 +522,7 @@ func TestClient_GetSafe(t *testing.T) {
 			assert.Equal(t, tt.serverResponse.Address, resp.Address)
 			assert.Equal(t, tt.serverResponse.Nonce, resp.Nonce)
 			assert.Equal(t, tt.serverResponse.Threshold, resp.Threshold)
-			assert.Equal(t, len(tt.serverResponse.Owners), len(resp.Owners))
+			assert.Len(t, resp.Owners, len(tt.serverResponse.Owners))
 		})
 	}
 }
@@ -512,8 +535,11 @@ func TestClient_AuthorizationHeader(t *testing.T) {
 		authHeader := r.Header.Get("Authorization")
 		assert.Equal(t, "Bearer "+apiKey, authHeader)
 
-		err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{})
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -553,11 +579,14 @@ func TestClient_RateLimitRetry(t *testing.T) {
 		// Second request succeeds
 		w.WriteHeader(http.StatusOK)
 
-		err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{
+		if err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{
 			Count:   1,
 			Results: []safe.MultisigTransaction{{SafeTxHash: "0xabc"}},
-		})
-		require.NoError(t, err)
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -576,6 +605,93 @@ func TestClient_RateLimitRetry(t *testing.T) {
 
 	mu.Lock()
 	assert.Equal(t, 2, requestCount, "expected exactly 2 requests (initial + retry)")
+	mu.Unlock()
+}
+
+func TestClient_RateLimitRetry_MultipleConsecutive429s(t *testing.T) {
+	var requestCount int
+
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		requestCount++
+
+		count := requestCount
+
+		if count <= 2 {
+			// First two requests return 429
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+
+			return
+		}
+
+		// Third request succeeds
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(&safe.MultisigTransactionsResponse{
+			Count:   1,
+			Results: []safe.MultisigTransaction{{SafeTxHash: "0xabc"}},
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	c, err := safe.NewClient(context.Background(), logrus.New(), "test", &safe.Config{
+		Endpoint: server.URL,
+		APIKey:   "test-key",
+	})
+	require.NoError(t, err)
+
+	c.SetChain("eth")
+
+	resp, err := c.GetQueuedTransactions(context.Background(), "0x123", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.Count)
+	assert.Equal(t, "0xabc", resp.Results[0].SafeTxHash)
+
+	mu.Lock()
+	assert.Equal(t, 3, requestCount, "expected 3 requests (initial + 2 retries)")
+	mu.Unlock()
+}
+
+func TestClient_RateLimitRetry_Exhaustion(t *testing.T) {
+	var requestCount int
+
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		requestCount++
+
+		// Always return 429 with short retry
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	c, err := safe.NewClient(context.Background(), logrus.New(), "test", &safe.Config{
+		Endpoint: server.URL,
+		APIKey:   "test-key",
+	})
+	require.NoError(t, err)
+
+	c.SetChain("eth")
+
+	_, err = c.GetQueuedTransactions(context.Background(), "0x123", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit retries exhausted")
+
+	mu.Lock()
+	// 1 initial + 5 retries = 6 total requests
+	assert.Equal(t, 6, requestCount, "expected 6 requests (initial + 5 retries)")
 	mu.Unlock()
 }
 
@@ -599,7 +715,7 @@ func TestClient_RateLimitRetry_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	_, err = c.GetQueuedTransactions(ctx, "0x123", 0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -626,6 +742,6 @@ func TestClient_RateLimitRetry_DefaultDelay(t *testing.T) {
 	defer cancel()
 
 	_, err = c.GetQueuedTransactions(ctx, "0x123", 0)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/pkg/monitor/safe/config.go
+++ b/pkg/monitor/safe/config.go
@@ -1,6 +1,6 @@
 package safe
 
-import "fmt"
+import "errors"
 
 // ChainIDToName maps chain IDs to their Safe API chain names.
 var ChainIDToName = map[string]string{
@@ -23,11 +23,11 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
+		return errors.New("endpoint is required")
 	}
 
 	if c.APIKey == "" {
-		return fmt.Errorf("apiKey is required for Transaction Service API")
+		return errors.New("apiKey is required for Transaction Service API")
 	}
 
 	return nil

--- a/pkg/monitor/server.go
+++ b/pkg/monitor/server.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os/signal"
 	"syscall"
@@ -92,7 +93,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if s.config.PProfAddr != nil {
 		g.Go(func() error {
 			if err := s.startPProf(); err != nil {
-				if err != http.ErrServerClosed {
+				if !errors.Is(err, http.ErrServerClosed) {
 					return err
 				}
 			}
@@ -104,7 +105,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if s.config.HealthCheckAddr != nil {
 		g.Go(func() error {
 			if err := s.startHealthCheck(); err != nil {
-				if err != http.ErrServerClosed {
+				if !errors.Is(err, http.ErrServerClosed) {
 					return err
 				}
 			}
@@ -133,7 +134,7 @@ func (s *Server) Start(ctx context.Context) error {
 		return s.stop(ctx)
 	})
 
-	if err := g.Wait(); err != context.Canceled {
+	if err := g.Wait(); !errors.Is(err, context.Canceled) {
 		return err
 	}
 

--- a/pkg/monitor/service/raw_message.go
+++ b/pkg/monitor/service/raw_message.go
@@ -1,15 +1,15 @@
 package service
 
 type RawMessage struct {
-	unmarshal func(interface{}) error
+	unmarshal func(any) error
 }
 
-func (r *RawMessage) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *RawMessage) UnmarshalYAML(unmarshal func(any) error) error {
 	r.unmarshal = unmarshal
 
 	return nil
 }
 
-func (r *RawMessage) Unmarshal(v interface{}) error {
+func (r *RawMessage) Unmarshal(v any) error {
 	return r.unmarshal(v)
 }

--- a/pkg/monitor/service/split/group/account/account.go
+++ b/pkg/monitor/service/split/group/account/account.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xsequence/ethkit/ethcoder"
 	spl "github.com/ethpandaops/splitoor/pkg/0xsplits/split"
 	"github.com/ethpandaops/splitoor/pkg/ethereum"
+	"github.com/ethpandaops/splitoor/pkg/ethereum/execution"
 	"github.com/sirupsen/logrus"
 )
 
@@ -83,38 +84,58 @@ func (a *Account) Allocation() uint32 {
 
 func (a *Account) tick(ctx context.Context) {
 	for _, node := range a.ethereumPool.GetHealthyExecutionNodes() {
-		balance, err := node.BalanceAt(ctx, a.address)
-		if err != nil {
-			a.log.WithError(err).WithField("node", node.Name()).Error("Error fetching balance")
+		if ctx.Err() != nil {
+			return
 		}
 
-		if balance == nil {
-			a.log.WithField("node", node.Name()).Error("Balance is nil")
-
-			continue
-		}
-
-		balanceFloat := new(big.Float).SetInt(balance)
-		balanceFloat64, _ := balanceFloat.Float64()
-
-		a.metrics.UpdateBalance(balanceFloat64, []string{a.name, node.Name(), a.address})
-
-		if a.client != nil && a.contract != nil {
-			balance, err := a.client.GetETHBalance(ctx, node, a.contract, a.address)
-			if err != nil {
-				a.log.WithError(err).WithField("node", node.Name()).Error("Error fetching split account balance")
+		if err := a.gatherNodeMetrics(ctx, node); err != nil {
+			if ctx.Err() != nil {
+				return
 			}
-
-			if balance == nil {
-				a.log.WithField("node", node.Name()).Error("Split account balance is nil")
-
-				continue
-			}
-
-			splitBalanceFloat := new(big.Float).SetInt(balance)
-			splitBalanceFloat64, _ := splitBalanceFloat.Float64()
-
-			a.metrics.UpdateSplitBalance(splitBalanceFloat64, []string{a.name, node.Name(), a.address})
 		}
 	}
+}
+
+func (a *Account) gatherNodeMetrics(ctx context.Context, node *execution.Node) error {
+	balance, err := node.BalanceAt(ctx, a.address)
+	if err != nil {
+		a.log.WithError(err).WithField("node", node.Name()).Error("Error fetching balance")
+
+		return err
+	}
+
+	if balance == nil {
+		a.log.WithField("node", node.Name()).Error("Balance is nil")
+
+		return nil
+	}
+
+	balanceFloat := new(big.Float).SetInt(balance)
+	balanceFloat64, _ := balanceFloat.Float64()
+
+	a.metrics.UpdateBalance(balanceFloat64, []string{a.name, node.Name(), a.address})
+
+	if a.client == nil || a.contract == nil {
+		return nil
+	}
+
+	splitBalance, err := a.client.GetETHBalance(ctx, node, a.contract, a.address)
+	if err != nil {
+		a.log.WithError(err).WithField("node", node.Name()).Error("Error fetching split account balance")
+
+		return err
+	}
+
+	if splitBalance == nil {
+		a.log.WithField("node", node.Name()).Error("Split account balance is nil")
+
+		return nil
+	}
+
+	splitBalanceFloat := new(big.Float).SetInt(splitBalance)
+	splitBalanceFloat64, _ := splitBalanceFloat.Float64()
+
+	a.metrics.UpdateSplitBalance(splitBalanceFloat64, []string{a.name, node.Name(), a.address})
+
+	return nil
 }

--- a/pkg/monitor/service/split/group/account/config.go
+++ b/pkg/monitor/service/split/group/account/config.go
@@ -1,7 +1,7 @@
 package account
 
 import (
-	"fmt"
+	"errors"
 )
 
 type Config struct {
@@ -13,23 +13,23 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	if c.Name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 
 	if c.Address == "" {
-		return fmt.Errorf("address is required")
+		return errors.New("address is required")
 	}
 
 	if c.Allocation <= 0 {
-		return fmt.Errorf("allocations must be greater than 0")
+		return errors.New("allocations must be greater than 0")
 	}
 
 	if c.Allocation > 999999 {
-		return fmt.Errorf("allocation must be less than 999999 (99.9999%%)")
+		return errors.New("allocation must be less than 999999 (99.9999%%)")
 	}
 
 	return nil

--- a/pkg/monitor/service/split/group/config.go
+++ b/pkg/monitor/service/split/group/config.go
@@ -1,10 +1,9 @@
 package group
 
 import (
-	"fmt"
-
 	"github.com/ethpandaops/splitoor/pkg/monitor/service/split/group/account"
 	"github.com/ethpandaops/splitoor/pkg/monitor/service/split/group/controller"
+	"github.com/pkg/errors"
 )
 
 type Config struct {
@@ -22,15 +21,15 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 
 	if c.Address == "" {
-		return fmt.Errorf("address is required")
+		return errors.New("address is required")
 	}
 
 	if c.RecoveryAddress == "" {
-		return fmt.Errorf("recoveryAddress is required")
+		return errors.New("recoveryAddress is required")
 	}
 
 	totalAllocation := uint32(0)
@@ -44,7 +43,7 @@ func (c *Config) Validate() error {
 	}
 
 	if totalAllocation != 1000000 {
-		return fmt.Errorf("total allocation must be 1000000 (100%%)")
+		return errors.New("total allocation must be 1000000 (100%%)")
 	}
 
 	if err := c.Controller.Validate(); err != nil {

--- a/pkg/monitor/service/split/group/config_test.go
+++ b/pkg/monitor/service/split/group/config_test.go
@@ -8,219 +8,130 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigValidate(t *testing.T) {
-	tests := []struct {
-		name        string
-		config      *Config
-		expectError bool
-	}{
-		{
-			name: "valid config - full config",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 999999,
-					},
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1,
-					},
-				},
-				Controller: controller.Config{
-					ControllerType: controller.ControllerTypeEOA,
-				},
+// validBaseConfig returns a valid Config that individual tests can modify.
+func validBaseConfig() *Config {
+	return &Config{
+		Name:            "test_group",
+		Address:         "0x123",
+		RecoveryAddress: "0x789",
+		Accounts: []*account.Config{
+			{
+				Name:       "account1",
+				Address:    "0x456",
+				Allocation: 999999,
 			},
-			expectError: false,
+			{
+				Name:       "account2",
+				Address:    "0x456",
+				Allocation: 1,
+			},
 		},
-		{
-			name: "invalid config - one account",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1000000,
-					},
-				},
-			},
-			expectError: true,
+		Controller: controller.Config{
+			ControllerType: controller.ControllerTypeEOA,
 		},
+	}
+}
+
+func TestConfigValidate_Valid(t *testing.T) {
+	cfg := validBaseConfig()
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_OneAccount(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Accounts = []*account.Config{
 		{
-			name: "invalid config - no accounts",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts:        []*account.Config{},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - bad account allocations",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1000000,
-					},
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1000000,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - empty name",
-			config: &Config{
-				Name:            "",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 999999,
-					},
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - empty address",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 999999,
-					},
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - empty recovery address",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 999999,
-					},
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - invalid total allocation",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 500000,
-					},
-					{
-						Name:       "account2",
-						Address:    "0x789",
-						Allocation: 400000,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - invalid account",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "",
-						Address:    "0x456",
-						Allocation: 1000000,
-					},
-				},
-			},
-			expectError: true,
-		},
-		{
-			name: "invalid config - invalid controller",
-			config: &Config{
-				Name:            "test_group",
-				Address:         "0x123",
-				RecoveryAddress: "0x789",
-				Accounts: []*account.Config{
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 999999,
-					},
-					{
-						Name:       "account1",
-						Address:    "0x456",
-						Allocation: 1,
-					},
-				},
-				Controller: controller.Config{
-					ControllerType: controller.ControllerTypeUnknown,
-				},
-			},
-			expectError: true,
+			Name:       "account1",
+			Address:    "0x456",
+			Allocation: 1000000,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.Validate()
-			if tt.expectError {
-				assert.Error(t, err)
+	assert.Error(t, cfg.Validate())
+}
 
-				return
-			}
+func TestConfigValidate_NoAccounts(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Accounts = []*account.Config{}
 
-			assert.NoError(t, err)
-		})
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_BadAllocations(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Accounts = []*account.Config{
+		{
+			Name:       "account1",
+			Address:    "0x456",
+			Allocation: 1000000,
+		},
+		{
+			Name:       "account2",
+			Address:    "0x456",
+			Allocation: 1000000,
+		},
 	}
+
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_EmptyName(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Name = ""
+
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_EmptyAddress(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Address = ""
+
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_EmptyRecoveryAddress(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.RecoveryAddress = ""
+
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_InvalidTotalAllocation(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Accounts = []*account.Config{
+		{
+			Name:       "account1",
+			Address:    "0x456",
+			Allocation: 500000,
+		},
+		{
+			Name:       "account2",
+			Address:    "0x789",
+			Allocation: 400000,
+		},
+	}
+
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_InvalidAccount(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Accounts = []*account.Config{
+		{
+			Name:       "",
+			Address:    "0x456",
+			Allocation: 1000000,
+		},
+	}
+
+	assert.Error(t, cfg.Validate())
+}
+
+func TestConfigValidate_InvalidController(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.Controller = controller.Config{
+		ControllerType: controller.ControllerTypeUnknown,
+	}
+
+	assert.Error(t, cfg.Validate())
 }

--- a/pkg/monitor/service/split/group/controller/config.go
+++ b/pkg/monitor/service/split/group/controller/config.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"fmt"
+	"errors"
 )
 
 type Config struct {
@@ -19,11 +19,11 @@ const (
 
 func (c *Config) Validate() error {
 	if c == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	if c.ControllerType == ControllerTypeUnknown || c.ControllerType == "" {
-		return fmt.Errorf("controller type is required")
+		return errors.New("controller type is required")
 	}
 
 	return nil

--- a/pkg/monitor/service/split/group/controller/controller.go
+++ b/pkg/monitor/service/split/group/controller/controller.go
@@ -27,7 +27,7 @@ func NewController(ctx context.Context, log logrus.FieldLogger, monitor, name st
 		return nil, errors.New("controller type is required")
 	}
 
-	switch controllerType {
+	switch controllerType { //nolint:exhaustive // ControllerTypeUnknown is handled above
 	case ControllerTypeEOA:
 		conf := &eoa.Config{}
 

--- a/pkg/monitor/service/split/group/controller/eoa/config.go
+++ b/pkg/monitor/service/split/group/controller/eoa/config.go
@@ -1,6 +1,6 @@
 package eoa
 
-import "fmt"
+import "errors"
 
 type Config struct {
 	Address string `yaml:"address"`
@@ -8,11 +8,11 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	if c.Address == "" {
-		return fmt.Errorf("address is required")
+		return errors.New("address is required")
 	}
 
 	return nil

--- a/pkg/monitor/service/split/group/controller/eoa/eoa.go
+++ b/pkg/monitor/service/split/group/controller/eoa/eoa.go
@@ -71,8 +71,16 @@ func (c *EOA) tick(ctx context.Context) {
 
 func (c *EOA) gatherMetrics(ctx context.Context) {
 	for _, node := range c.ethereumPool.GetHealthyExecutionNodes() {
+		if ctx.Err() != nil {
+			return
+		}
+
 		balance, err := node.BalanceAt(ctx, c.address)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
 			c.log.WithError(err).WithField("node", node.Name()).Error("Error fetching balance")
 		}
 

--- a/pkg/monitor/service/split/group/controller/raw_message.go
+++ b/pkg/monitor/service/split/group/controller/raw_message.go
@@ -1,15 +1,15 @@
 package controller
 
 type RawMessage struct {
-	unmarshal func(interface{}) error
+	unmarshal func(any) error
 }
 
-func (r *RawMessage) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *RawMessage) UnmarshalYAML(unmarshal func(any) error) error {
 	r.unmarshal = unmarshal
 
 	return nil
 }
 
-func (r *RawMessage) Unmarshal(v interface{}) error {
+func (r *RawMessage) Unmarshal(v any) error {
 	return r.unmarshal(v)
 }

--- a/pkg/monitor/service/split/group/controller/safe/config.go
+++ b/pkg/monitor/service/split/group/controller/safe/config.go
@@ -1,6 +1,6 @@
 package safe
 
-import "fmt"
+import "errors"
 
 type Config struct {
 	Address   string   `yaml:"address"`
@@ -10,19 +10,19 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c == nil {
-		return fmt.Errorf("config is nil")
+		return errors.New("config is nil")
 	}
 
 	if c.Address == "" {
-		return fmt.Errorf("address is required")
+		return errors.New("address is required")
 	}
 
 	if c.Threshold == 0 {
-		return fmt.Errorf("threshold is required")
+		return errors.New("threshold is required")
 	}
 
 	if len(c.Signers) == 0 {
-		return fmt.Errorf("signers is required")
+		return errors.New("signers is required")
 	}
 
 	return nil

--- a/pkg/monitor/service/split/group/controller/safe/safe.go
+++ b/pkg/monitor/service/split/group/controller/safe/safe.go
@@ -127,13 +127,17 @@ func (c *Safe) tick(ctx context.Context) {
 
 	safeRsp, err := c.safeClient.GetSafe(ctx, c.address)
 	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+
 		c.log.WithError(err).Error("failed to get safe")
 
 		return
 	}
 
 	// Check signers and threshold
-	c.checkSignersAndThreshold(ctx, safeRsp)
+	c.checkSignersAndThreshold(safeRsp)
 
 	// Get and process queued transactions
 	queuedTxData, err := c.getQueuedTransactions(ctx, safeRsp.Nonce)
@@ -142,14 +146,14 @@ func (c *Safe) tick(ctx context.Context) {
 	}
 
 	// Process alerts based on transaction data
-	c.processTransactionAlerts(ctx, queuedTxData)
+	c.processTransactionAlerts(queuedTxData)
 
 	// Update metrics based on transaction data
 	c.updateTransactionMetrics(queuedTxData)
 }
 
 // checkSignersAndThreshold verifies signers and threshold match expectations.
-func (c *Safe) checkSignersAndThreshold(ctx context.Context, safeRsp *safe.SafeResponse) {
+func (c *Safe) checkSignersAndThreshold(safeRsp *safe.SafeResponse) {
 	// Check signers
 	signersMatch := safeRsp.CheckSigners(c.signers)
 
@@ -191,7 +195,9 @@ type TransactionData struct {
 func (c *Safe) getQueuedTransactions(ctx context.Context, safeNonce int64) (*TransactionData, error) {
 	queued, err := c.safeClient.GetQueuedTransactions(ctx, c.address, safeNonce)
 	if err != nil {
-		c.log.WithError(err).Error("failed to get queued transactions")
+		if ctx.Err() == nil {
+			c.log.WithError(err).Error("failed to get queued transactions")
+		}
 
 		return nil, err
 	}
@@ -209,10 +215,10 @@ func (c *Safe) getQueuedTransactions(ctx context.Context, safeNonce int64) (*Tra
 	}
 
 	// Process transactions to find valid recovery transactions
-	if err := c.processTransactions(ctx, txData); err != nil {
-		c.log.WithError(err).Error("failed to process transactions")
+	if processErr := c.processTransactions(ctx, txData); processErr != nil {
+		c.log.WithError(processErr).Error("failed to process transactions")
 
-		return nil, err
+		return nil, processErr
 	}
 
 	return txData, nil
@@ -223,7 +229,9 @@ func (c *Safe) processTransactions(ctx context.Context, txData *TransactionData)
 	for i, tx := range txData.Transactions {
 		txDetails, err := c.safeClient.GetTransaction(ctx, tx.SafeTxHash)
 		if err != nil {
-			c.log.WithError(err).Error("failed to get recovery transaction details")
+			if ctx.Err() == nil {
+				c.log.WithError(err).Error("failed to get recovery transaction details")
+			}
 
 			return err
 		}
@@ -233,7 +241,7 @@ func (c *Safe) processTransactions(ctx context.Context, txData *TransactionData)
 				"safe_tx_hash": tx.SafeTxHash,
 			}).Warn("failed to get recovery transaction details")
 
-			return fmt.Errorf("failed to get recovery transaction details")
+			return errors.New("failed to get recovery transaction details")
 		}
 
 		if !c.isValidRecoveryTransaction(tx.SafeTxHash, txDetails) {
@@ -243,12 +251,12 @@ func (c *Safe) processTransactions(ctx context.Context, txData *TransactionData)
 		txData.RecoveryTxHash = tx.SafeTxHash
 		txData.InvalidRecoveryError = nil
 
-		if err := c.checkRecoveryParameters(txDetails); err != nil {
+		if checkErr := c.checkRecoveryParameters(txDetails); checkErr != nil {
 			c.log.WithFields(logrus.Fields{
 				"safe_tx_hash": tx.SafeTxHash,
-			}).WithError(err).Warn("invalid recovery transaction queued")
+			}).WithError(checkErr).Warn("invalid recovery transaction queued")
 
-			txData.InvalidRecoveryError = err
+			txData.InvalidRecoveryError = checkErr
 
 			continue
 		}
@@ -309,25 +317,25 @@ func (c *Safe) isValidRecoveryTransaction(safeTxHash string, txDetails *safe.Mul
 }
 
 // processTransactionAlerts processes various alerts based on transaction data.
-func (c *Safe) processTransactionAlerts(ctx context.Context, txData *TransactionData) {
+func (c *Safe) processTransactionAlerts(txData *TransactionData) {
 	// Check if queue size is too large
-	c.alertQueueExcess(ctx, len(txData.Transactions))
+	c.alertQueueExcess(len(txData.Transactions))
 
 	// Check for missing recovery transaction
-	c.alertMissingRecovery(ctx, txData.RecoveryTxHash)
+	c.alertMissingRecovery(txData.RecoveryTxHash)
 
 	// Check for invalid recovery transaction
-	c.alertInvalidRecovery(ctx, txData.RecoveryTxHash, txData.InvalidRecoveryError)
+	c.alertInvalidRecovery(txData.RecoveryTxHash, txData.InvalidRecoveryError)
 
 	// Check if recovery transaction is not next in queue
-	c.alertNotNextRecovery(ctx, txData)
+	c.alertNotNextRecovery(txData)
 
 	// Check confirmation status
-	c.alertConfirmationStatus(ctx, txData)
+	c.alertConfirmationStatus(txData)
 }
 
 // alertQueueExcess checks and alerts if queue size is too large.
-func (c *Safe) alertQueueExcess(ctx context.Context, queueSize int) {
+func (c *Safe) alertQueueExcess(queueSize int) {
 	shouldAlert := c.excessQueue.Update(queueSize)
 	if shouldAlert {
 		c.log.WithFields(logrus.Fields{
@@ -341,7 +349,7 @@ func (c *Safe) alertQueueExcess(ctx context.Context, queueSize int) {
 }
 
 // alertMissingRecovery checks and alerts if recovery transaction is missing.
-func (c *Safe) alertMissingRecovery(ctx context.Context, recoveryTx string) {
+func (c *Safe) alertMissingRecovery(recoveryTx string) {
 	shouldAlert := c.missing.Update(recoveryTx == "")
 	if shouldAlert {
 		c.log.Warn("Alerting recovery transaction missing")
@@ -353,7 +361,7 @@ func (c *Safe) alertMissingRecovery(ctx context.Context, recoveryTx string) {
 }
 
 // alertInvalidRecovery checks and alerts if recovery transaction is invalid.
-func (c *Safe) alertInvalidRecovery(ctx context.Context, recoveryTx string, invalidError error) {
+func (c *Safe) alertInvalidRecovery(recoveryTx string, invalidError error) {
 	shouldAlert := c.invalid.Update(invalidError)
 	if shouldAlert && invalidError != nil {
 		c.log.WithFields(logrus.Fields{
@@ -367,7 +375,7 @@ func (c *Safe) alertInvalidRecovery(ctx context.Context, recoveryTx string, inva
 }
 
 // alertNotNextRecovery checks and alerts if recovery transaction is not next in queue.
-func (c *Safe) alertNotNextRecovery(ctx context.Context, txData *TransactionData) {
+func (c *Safe) alertNotNextRecovery(txData *TransactionData) {
 	shouldAlert := c.next.Update(txData.RecoveryTxHash != "", txData.InvalidRecoveryError == nil, txData.HasNextRecoveryTx)
 	if shouldAlert {
 		c.log.WithFields(logrus.Fields{
@@ -381,7 +389,7 @@ func (c *Safe) alertNotNextRecovery(ctx context.Context, txData *TransactionData
 }
 
 // alertConfirmationStatus checks and alerts about confirmation status.
-func (c *Safe) alertConfirmationStatus(ctx context.Context, txData *TransactionData) {
+func (c *Safe) alertConfirmationStatus(txData *TransactionData) {
 	expectedConfirmations := txData.RequiredConfirmations - 1
 	// Handle special case where a safe multisig only requires 1 confirmation
 	if txData.RequiredConfirmations == 1 {
@@ -467,18 +475,18 @@ func (c *Safe) checkRecoveryParameters(tx *safe.MultisigTransaction) error {
 	}
 
 	// Validate array lengths
-	if err := c.validateArrayLengths(params.Accounts, params.Allocations); err != nil {
-		return err
+	if validateErr := c.validateArrayLengths(params.Accounts, params.Allocations); validateErr != nil {
+		return validateErr
 	}
 
 	// Validate accounts and allocations
-	if err := c.validateAccountsAndAllocations(params.Accounts, params.Allocations); err != nil {
-		return err
+	if validateErr := c.validateAccountsAndAllocations(params.Accounts, params.Allocations); validateErr != nil {
+		return validateErr
 	}
 
 	// Validate distributor fee
 	if params.DistributorFee != 0 {
-		return fmt.Errorf("distributor fee must be 0")
+		return errors.New("distributor fee must be 0")
 	}
 
 	return nil
@@ -488,15 +496,15 @@ func (c *Safe) checkRecoveryParameters(tx *safe.MultisigTransaction) error {
 func (c *Safe) validateTxBasics(tx *safe.MultisigTransaction) error {
 	// First, verify tx and its data are not nil
 	if tx == nil {
-		return fmt.Errorf("transaction details is nil")
+		return errors.New("transaction details is nil")
 	}
 
 	if tx.DataDecoded == nil {
-		return fmt.Errorf("transaction data decoded is nil")
+		return errors.New("transaction data decoded is nil")
 	}
 
 	if tx.DataDecoded.Parameters == nil {
-		return fmt.Errorf("transaction parameters are nil")
+		return errors.New("transaction parameters are nil")
 	}
 
 	return nil
@@ -548,9 +556,9 @@ func (c *Safe) parseSplitAddress(param safe.Parameter, result *TransactionParams
 
 // parseAccounts parses the accounts parameter.
 func (c *Safe) parseAccounts(param safe.Parameter, result *TransactionParams) error {
-	accountsIface, ok := param.Value.([]interface{})
+	accountsIface, ok := param.Value.([]any)
 	if !ok {
-		return fmt.Errorf("invalid accounts value: expected []interface{}, got %T (%v)", param.Value, param.Value)
+		return fmt.Errorf("invalid accounts value: expected []any, got %T (%v)", param.Value, param.Value)
 	}
 
 	result.Accounts = make([]string, len(accountsIface))
@@ -571,9 +579,9 @@ func (c *Safe) parseAccounts(param safe.Parameter, result *TransactionParams) er
 
 // parseAllocations parses the percentage allocations parameter.
 func (c *Safe) parseAllocations(param safe.Parameter, result *TransactionParams) error {
-	allocsIface, ok := param.Value.([]interface{})
+	allocsIface, ok := param.Value.([]any)
 	if !ok {
-		return fmt.Errorf("invalid percentAllocations value: expected []interface{}, got %T (%v)", param.Value, param.Value)
+		return fmt.Errorf("invalid percentAllocations value: expected []any, got %T (%v)", param.Value, param.Value)
 	}
 
 	result.Allocations = make([]uint32, len(allocsIface))
@@ -583,14 +591,14 @@ func (c *Safe) parseAllocations(param safe.Parameter, result *TransactionParams)
 			return fmt.Errorf("allocation at index %d is nil", i)
 		}
 
-		aStr, ok := a.(string)
-		if !ok {
+		aStr, aOk := a.(string)
+		if !aOk {
 			return fmt.Errorf("invalid allocation value type at index %d: expected string, got %T (%v)", i, a, a)
 		}
 
 		val, err := strconv.ParseUint(aStr, 10, 32)
 		if err != nil {
-			return fmt.Errorf("invalid allocation value at index %d: %v", i, err)
+			return fmt.Errorf("invalid allocation value at index %d: %w", i, err)
 		}
 
 		result.Allocations[i] = uint32(val)
@@ -608,7 +616,7 @@ func (c *Safe) parseDistributorFee(param safe.Parameter, result *TransactionPara
 
 	val, err := strconv.ParseUint(feeStr, 10, 32)
 	if err != nil {
-		return fmt.Errorf("invalid distributor fee value: %v", err)
+		return fmt.Errorf("invalid distributor fee value: %w", err)
 	}
 
 	result.DistributorFee = uint32(val)
@@ -620,11 +628,11 @@ func (c *Safe) parseDistributorFee(param safe.Parameter, result *TransactionPara
 func (c *Safe) validateArrayLengths(accounts []string, allocations []uint32) error {
 	// Check for nil slices
 	if c.recoveryAccounts == nil {
-		return fmt.Errorf("recovery accounts is nil")
+		return errors.New("recovery accounts is nil")
 	}
 
 	if c.recoveryAllocations == nil {
-		return fmt.Errorf("recovery allocations is nil")
+		return errors.New("recovery allocations is nil")
 	}
 
 	// Check array lengths match
@@ -676,8 +684,16 @@ func (c *Safe) validateAccountsAndAllocations(accounts []string, allocations []u
 
 func (c *Safe) gatherMetrics(ctx context.Context) {
 	for _, node := range c.ethereumPool.GetHealthyExecutionNodes() {
+		if ctx.Err() != nil {
+			return
+		}
+
 		balance, err := node.BalanceAt(ctx, c.address)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
 			c.log.WithError(err).WithField("node", node.Name()).Error("Error fetching balance")
 		}
 

--- a/pkg/monitor/service/split/group/group.go
+++ b/pkg/monitor/service/split/group/group.go
@@ -285,8 +285,8 @@ func (g *Group) checkController(ctx context.Context) {
 				"actual_controller":   *actualController,
 			}).Warn("Alerting controller mismatch")
 
-			if err := g.publisher.Publish(event.NewController(time.Now(), g.monitor, g.name, g.address, g.controller.Address(), *actualController)); err != nil {
-				g.log.WithError(err).WithFields(logrus.Fields{
+			if pubErr := g.publisher.Publish(event.NewController(time.Now(), g.monitor, g.name, g.address, g.controller.Address(), *actualController)); pubErr != nil {
+				g.log.WithError(pubErr).WithFields(logrus.Fields{
 					"split_address":       g.address,
 					"expected_controller": g.controller.Address(),
 					"actual_controller":   *actualController,
@@ -311,115 +311,100 @@ func (g *Group) checkHash(ctx context.Context) {
 
 		actualHashString := hex.EncodeToString(actualHash[:])
 
-		// Get previous hash values from alerts and clear previous metrics if hash has changed
-		previousHashUnknown := g.hashUnknownAlert.GetHash()
-		previousHashInitial := g.hashInitialAlert.GetHash()
-		previousHashRecovery := g.hashRecoveryAlert.GetHash()
+		g.clearStaleHashMetrics(node.Name(), actualHashString)
+		g.updateHashMetrics(node.Name(), actualHashString)
+		g.checkHashAlerts(actualHashString)
+	}
+}
 
-		if previousHashUnknown != "" && previousHashUnknown != actualHashString {
-			g.metrics.ClearHashStable([]string{g.name, node.Name(), g.address, g.stableHash, previousHashUnknown})
-			g.metrics.ClearHashInitial([]string{g.name, node.Name(), g.address, g.initialHash, previousHashUnknown})
-			g.metrics.ClearHashRecovery([]string{g.name, node.Name(), g.address, g.recoveryHash, previousHashUnknown})
-			g.metrics.ClearHashUnexpected([]string{g.name, node.Name(), g.address, previousHashUnknown})
+func (g *Group) clearStaleHashMetrics(nodeName, actualHash string) {
+	previousHashes := []string{
+		g.hashUnknownAlert.GetHash(),
+		g.hashInitialAlert.GetHash(),
+		g.hashRecoveryAlert.GetHash(),
+	}
+
+	seen := make(map[string]bool, len(previousHashes))
+
+	for _, prev := range previousHashes {
+		if prev == "" || prev == actualHash || seen[prev] {
+			continue
 		}
 
-		if previousHashInitial != previousHashUnknown && previousHashInitial != "" && previousHashInitial != actualHashString {
-			g.metrics.ClearHashStable([]string{g.name, node.Name(), g.address, g.stableHash, previousHashInitial})
-			g.metrics.ClearHashInitial([]string{g.name, node.Name(), g.address, g.initialHash, previousHashInitial})
-			g.metrics.ClearHashRecovery([]string{g.name, node.Name(), g.address, g.recoveryHash, previousHashInitial})
-			g.metrics.ClearHashUnexpected([]string{g.name, node.Name(), g.address, previousHashInitial})
+		seen[prev] = true
+
+		g.metrics.ClearHashStable([]string{g.name, nodeName, g.address, g.stableHash, prev})
+		g.metrics.ClearHashInitial([]string{g.name, nodeName, g.address, g.initialHash, prev})
+		g.metrics.ClearHashRecovery([]string{g.name, nodeName, g.address, g.recoveryHash, prev})
+		g.metrics.ClearHashUnexpected([]string{g.name, nodeName, g.address, prev})
+	}
+}
+
+func (g *Group) updateHashMetrics(nodeName, actualHash string) {
+	boolFloat := func(cond bool) float64 {
+		if cond {
+			return 1
 		}
 
-		if previousHashRecovery != previousHashUnknown && previousHashRecovery != previousHashInitial &&
-			previousHashRecovery != "" && previousHashRecovery != actualHashString {
-			g.metrics.ClearHashStable([]string{g.name, node.Name(), g.address, g.stableHash, previousHashRecovery})
-			g.metrics.ClearHashInitial([]string{g.name, node.Name(), g.address, g.initialHash, previousHashRecovery})
-			g.metrics.ClearHashRecovery([]string{g.name, node.Name(), g.address, g.recoveryHash, previousHashRecovery})
-			g.metrics.ClearHashUnexpected([]string{g.name, node.Name(), g.address, previousHashRecovery})
+		return 0
+	}
+
+	g.metrics.UpdateHashStable(boolFloat(actualHash == g.stableHash), []string{g.name, nodeName, g.address, g.stableHash, actualHash})
+	g.metrics.UpdateHashInitial(boolFloat(actualHash == g.initialHash), []string{g.name, nodeName, g.address, g.initialHash, actualHash})
+	g.metrics.UpdateHashRecovery(boolFloat(actualHash == g.recoveryHash), []string{g.name, nodeName, g.address, g.recoveryHash, actualHash})
+	g.metrics.UpdateHashUnexpected(boolFloat(actualHash != g.stableHash && actualHash != g.initialHash && actualHash != g.recoveryHash), []string{g.name, nodeName, g.address, actualHash})
+}
+
+func (g *Group) checkHashAlerts(actualHash string) {
+	if g.hashUnknownAlert.Update(actualHash) {
+		g.log.WithFields(logrus.Fields{
+			"split_address": g.address,
+			"expected_hash": g.stableHash,
+			"actual_hash":   actualHash,
+		}).Warn("Alerting stable hash unknown")
+
+		if pubErr := g.publisher.Publish(event.NewHashUnknownState(time.Now(), g.monitor, g.name, g.address, g.stableHash, actualHash)); pubErr != nil {
+			g.log.WithError(pubErr).Error("Error publishing hash unknown alert")
 		}
+	}
 
-		stableHashVal := float64(0)
-		if actualHashString == g.stableHash {
-			stableHashVal = 1
+	if g.hashInitialAlert.Update(actualHash) {
+		g.log.WithFields(logrus.Fields{
+			"split_address": g.address,
+			"expected_hash": g.initialHash,
+			"actual_hash":   actualHash,
+		}).Warn("Alerting in initial hash state")
+
+		if pubErr := g.publisher.Publish(event.NewHashInitialState(time.Now(), g.monitor, g.name, g.address, actualHash)); pubErr != nil {
+			g.log.WithError(pubErr).Error("Error publishing in initial hash state alert")
 		}
+	}
 
-		initialHashVal := float64(0)
-		if actualHashString == g.initialHash {
-			initialHashVal = 1
-		}
+	if g.hashRecoveryAlert.Update(actualHash) {
+		g.log.WithFields(logrus.Fields{
+			"split_address": g.address,
+			"expected_hash": g.recoveryHash,
+			"actual_hash":   actualHash,
+		}).Warn("Alerting in recovery hash state")
 
-		recoveryHashVal := float64(0)
-		if actualHashString == g.recoveryHash {
-			recoveryHashVal = 1
-		}
-
-		unexpectedHashVal := float64(0)
-		if actualHashString != g.stableHash && actualHashString != g.initialHash && actualHashString != g.recoveryHash {
-			unexpectedHashVal = 1
-		}
-
-		g.metrics.UpdateHashStable(stableHashVal, []string{g.name, node.Name(), g.address, g.stableHash, actualHashString})
-		g.metrics.UpdateHashInitial(initialHashVal, []string{g.name, node.Name(), g.address, g.initialHash, actualHashString})
-		g.metrics.UpdateHashRecovery(recoveryHashVal, []string{g.name, node.Name(), g.address, g.recoveryHash, actualHashString})
-		g.metrics.UpdateHashUnexpected(unexpectedHashVal, []string{g.name, node.Name(), g.address, actualHashString})
-
-		shouldAlertUnknown := g.hashUnknownAlert.Update(actualHashString)
-		if shouldAlertUnknown {
-			g.log.WithFields(logrus.Fields{
-				"split_address": g.address,
-				"expected_hash": g.stableHash,
-				"actual_hash":   actualHashString,
-			}).Warn("Alerting stable hash unknown")
-
-			if err := g.publisher.Publish(event.NewHashUnknownState(time.Now(), g.monitor, g.name, g.address, g.stableHash, actualHashString)); err != nil {
-				g.log.WithError(err).WithFields(logrus.Fields{
-					"split_address": g.address,
-					"expected_hash": g.stableHash,
-					"actual_hash":   actualHashString,
-				}).Error("Error publishing hash unknown alert")
-			}
-		}
-
-		shouldAlertInitial := g.hashInitialAlert.Update(actualHashString)
-		if shouldAlertInitial {
-			g.log.WithFields(logrus.Fields{
-				"split_address": g.address,
-				"expected_hash": g.initialHash,
-				"actual_hash":   actualHashString,
-			}).Warn("Alerting in initial hash state")
-
-			if err := g.publisher.Publish(event.NewHashInitialState(time.Now(), g.monitor, g.name, g.address, actualHashString)); err != nil {
-				g.log.WithError(err).WithFields(logrus.Fields{
-					"split_address": g.address,
-					"expected_hash": g.initialHash,
-					"actual_hash":   actualHashString,
-				}).Error("Error publishing in initial hash state alert")
-			}
-		}
-
-		shouldAlertRecovery := g.hashRecoveryAlert.Update(actualHashString)
-		if shouldAlertRecovery {
-			g.log.WithFields(logrus.Fields{
-				"split_address": g.address,
-				"expected_hash": g.recoveryHash,
-				"actual_hash":   actualHashString,
-			}).Warn("Alerting in recovery hash state")
-
-			if err := g.publisher.Publish(event.NewHashRecoveryState(time.Now(), g.monitor, g.name, g.address, actualHashString)); err != nil {
-				g.log.WithError(err).WithFields(logrus.Fields{
-					"split_address": g.address,
-					"expected_hash": g.recoveryHash,
-					"actual_hash":   actualHashString,
-				}).Error("Error publishing in recovery hash state alert")
-			}
+		if pubErr := g.publisher.Publish(event.NewHashRecoveryState(time.Now(), g.monitor, g.name, g.address, actualHash)); pubErr != nil {
+			g.log.WithError(pubErr).Error("Error publishing in recovery hash state alert")
 		}
 	}
 }
 
 func (g *Group) gatherMetrics(ctx context.Context) {
 	for _, node := range g.ethereumPool.GetHealthyExecutionNodes() {
+		if ctx.Err() != nil {
+			return
+		}
+
 		balance, err := node.BalanceAt(ctx, g.address)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
 			g.log.WithError(err).WithField("node", node.Name()).Error("Error fetching balance")
 		}
 

--- a/pkg/monitor/service/validator/group/config.go
+++ b/pkg/monitor/service/validator/group/config.go
@@ -1,6 +1,6 @@
 package group
 
-import "fmt"
+import "errors"
 
 type Config struct {
 	Name    string   `yaml:"name"`
@@ -13,7 +13,7 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 
 	return nil

--- a/pkg/monitor/service/validator/group/group.go
+++ b/pkg/monitor/service/validator/group/group.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/splitoor/pkg/ethereum"
+	"github.com/ethpandaops/splitoor/pkg/ethereum/beacon"
 	"github.com/ethpandaops/splitoor/pkg/monitor/beaconchain"
 	"github.com/ethpandaops/splitoor/pkg/monitor/event/validator"
 	"github.com/ethpandaops/splitoor/pkg/monitor/notifier"
@@ -53,10 +54,7 @@ func NewGroup(ctx context.Context, log logrus.FieldLogger, monitor string, conf 
 
 	if bc != nil {
 		for i := 0; i < len(conf.Pubkeys); i += bc.GetBatchSize() {
-			end := i + bc.GetBatchSize()
-			if end > len(conf.Pubkeys) {
-				end = len(conf.Pubkeys)
-			}
+			end := min(i+bc.GetBatchSize(), len(conf.Pubkeys))
 
 			chunks = append(chunks, conf.Pubkeys[i:end])
 		}
@@ -120,23 +118,15 @@ func (g *Group) tick(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	if g.beaconchain != nil && time.Since(g.beaconchainLastTick) > g.beaconchain.GetCheckInterval() {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			g.checkBeaconchain(ctx, newState)
-		}()
+		})
 	}
 
 	if g.ethereumPool != nil && g.ethereumPool.HasHealthyBeaconNodes() {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			g.checkBeaconAPI(ctx, newState)
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -150,38 +140,50 @@ func (g *Group) tick(ctx context.Context) {
 
 func (g *Group) checkBeaconAPI(ctx context.Context, state *State) {
 	for _, node := range g.ethereumPool.GetHealthyBeaconNodes() {
-		validators, err := node.Node().FetchValidators(ctx, "head", nil, g.pubkeys)
-		if err != nil {
-			g.log.WithError(err).WithField("source", node.Name()).Error("Error fetching validators")
+		if ctx.Err() != nil {
+			return
+		}
 
-			for _, pubkey := range g.pubkeys {
-				g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey.String(), node.Name()})
-			}
+		g.processBeaconNode(ctx, node, state)
+	}
+}
+
+func (g *Group) processBeaconNode(ctx context.Context, node *beacon.Node, state *State) {
+	validators, err := node.Node().FetchValidators(ctx, "head", nil, g.pubkeys)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+
+		g.log.WithError(err).WithField("source", node.Name()).Error("Error fetching validators")
+
+		for _, pubkey := range g.pubkeys {
+			g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey.String(), node.Name()})
+		}
+
+		return
+	}
+
+	foundPubkeys := make(map[string]bool, len(validators))
+
+	for _, validator := range validators {
+		g.updateValidatorBeaconAPI(validator, node.Name(), state)
+
+		pubkey, pubkeyErr := validator.PubKey(ctx)
+		if pubkeyErr != nil {
+			g.log.WithError(pubkeyErr).WithField("source", node.Name()).WithField("validator_index", validator.Index).Error("Error getting pubkey")
 
 			continue
 		}
 
-		foundPubkeys := make(map[string]bool)
+		foundPubkeys[pubkey.String()] = true
+	}
 
-		for _, validator := range validators {
-			g.updateValidatorBeaconAPI(validator, node.Name(), state)
+	for _, pubkey := range g.pubkeys {
+		if !foundPubkeys[pubkey.String()] {
+			g.log.WithField("pubkey", pubkey.String()).WithField("source", node.Name()).Warn("Validator not found")
 
-			pubkey, err := validator.PubKey(ctx)
-			if err != nil {
-				g.log.WithError(err).WithField("source", node.Name()).WithField("validator_index", validator.Index).Error("Error getting pubkey")
-
-				continue
-			}
-
-			foundPubkeys[pubkey.String()] = true
-		}
-
-		for _, pubkey := range g.pubkeys {
-			if !foundPubkeys[pubkey.String()] {
-				g.log.WithField("pubkey", pubkey.String()).WithField("source", node.Name()).Warn("Validator not found")
-
-				g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey.String(), node.Name()})
-			}
+			g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey.String(), node.Name()})
 		}
 	}
 }
@@ -235,44 +237,53 @@ func (g *Group) getValidatorsBeaconchain(ctx context.Context, validators []strin
 	}
 
 	if len(validators) == 1 {
-		response, err := g.beaconchain.GetValidator(ctx, validators[0])
-		if err != nil {
-			g.log.WithError(err).WithField("source", "beaconcha.in").WithField("pubkey", validators[0]).Error("Error getting validator")
-			g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, validators[0], "beaconcha.in"})
+		return g.getSingleValidatorBeaconchain(ctx, validators[0], state)
+	}
 
-			return err
+	return g.getMultipleValidatorsBeaconchain(ctx, validators, state)
+}
+
+func (g *Group) getSingleValidatorBeaconchain(ctx context.Context, pubkey string, state *State) error {
+	response, err := g.beaconchain.GetValidator(ctx, pubkey)
+	if err != nil {
+		g.log.WithError(err).WithField("source", "beaconcha.in").WithField("pubkey", pubkey).Error("Error getting validator")
+		g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey, "beaconcha.in"})
+
+		return err
+	}
+
+	g.updateValidatorBeaconchain(response, state)
+
+	return nil
+}
+
+func (g *Group) getMultipleValidatorsBeaconchain(ctx context.Context, validators []string, state *State) error {
+	response, err := g.beaconchain.GetValidators(ctx, validators)
+	if err != nil {
+		for _, pubkey := range validators {
+			g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey, "beaconcha.in"})
 		}
 
-		g.updateValidatorBeaconchain(response, state)
-	} else {
-		response, err := g.beaconchain.GetValidators(ctx, validators)
-		if err != nil {
-			for _, pubkey := range validators {
-				g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, pubkey, "beaconcha.in"})
-			}
+		g.log.WithError(err).WithField("source", "beaconcha.in").WithField("pubkeys", validators).Error("Error getting validators")
 
-			g.log.WithError(err).WithField("source", "beaconcha.in").WithField("pubkeys", validators).Error("Error getting validators")
+		return err
+	}
 
-			return err
+	foundPubkeys := make(map[string]bool, len(response))
+
+	for _, v := range response {
+		if v != nil {
+			g.updateValidatorBeaconchain(v, state)
+
+			foundPubkeys[v.Pubkey] = true
 		}
+	}
 
-		foundPubkeys := make(map[string]bool)
+	for _, requestedPubkey := range validators {
+		if !foundPubkeys[requestedPubkey] {
+			g.log.WithField("pubkey", requestedPubkey).WithField("source", "beaconcha.in").Warn("Validator not found")
 
-		for _, validator := range response {
-			if validator != nil {
-				g.updateValidatorBeaconchain(validator, state)
-
-				foundPubkeys[validator.Pubkey] = true
-			}
-		}
-
-		// Check only the validators we requested in this chunk
-		for _, requestedPubkey := range validators {
-			if !foundPubkeys[requestedPubkey] {
-				g.log.WithField("pubkey", requestedPubkey).WithField("source", "beaconcha.in").Warn("Validator not found")
-
-				g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, requestedPubkey, "beaconcha.in"})
-			}
+			g.metrics.UpdateStatus(MetricsStatusUnknown, []string{g.name, requestedPubkey, "beaconcha.in"})
 		}
 	}
 
@@ -358,54 +369,59 @@ func (g *Group) updateAlerts(changedPubkeys []string) {
 	defer g.mu.Unlock()
 
 	for _, pubkey := range changedPubkeys {
-		if _, exists := g.balanceAlerts[pubkey]; !exists {
-			g.balanceAlerts[pubkey] = alert.NewBalance(g.log, MinBalance)
+		g.ensureAlerts(pubkey)
+		g.checkPubkeyAlerts(pubkey)
+	}
+}
+
+func (g *Group) ensureAlerts(pubkey string) {
+	if _, exists := g.balanceAlerts[pubkey]; !exists {
+		g.balanceAlerts[pubkey] = alert.NewBalance(g.log, MinBalance)
+	}
+
+	if _, exists := g.statusAlerts[pubkey]; !exists {
+		g.statusAlerts[pubkey] = alert.NewStatus(g.log, ExpectedStatuses)
+	}
+
+	if _, exists := g.withdrawalCredentialsAlerts[pubkey]; !exists {
+		g.withdrawalCredentialsAlerts[pubkey] = alert.NewWithdrawalCredentials(g.log, WithdrawalCredentialsCodes)
+	}
+}
+
+func (g *Group) checkPubkeyAlerts(pubkey string) {
+	sources := g.validatorState.Validators[pubkey].Sources
+
+	balances := make([]uint64, 0, len(sources))
+	statuses := make([]string, 0, len(sources))
+	codes := make([]int64, 0, len(sources))
+
+	for _, source := range sources {
+		balances = append(balances, source.Balance)
+		statuses = append(statuses, string(source.Status))
+		codes = append(codes, source.WithdrawalCredentialsCode)
+	}
+
+	if shouldAlert, balance := g.balanceAlerts[pubkey].Update(balances); shouldAlert {
+		g.log.WithField("balance", *balance).WithField("pubkey", pubkey).Warn("Alerting min balance")
+
+		if err := g.publisher.Publish(validator.NewMinBalance(time.Now(), *balance, pubkey, g.name, g.monitor)); err != nil {
+			g.log.WithError(err).WithField("pubkey", pubkey).Error("Error publishing min balance alert")
 		}
+	}
 
-		if _, exists := g.statusAlerts[pubkey]; !exists {
-			g.statusAlerts[pubkey] = alert.NewStatus(g.log, ExpectedStatuses)
+	if shouldAlert, alertingStatus := g.statusAlerts[pubkey].Update(statuses); shouldAlert {
+		g.log.WithField("status", *alertingStatus).WithField("pubkey", pubkey).Warn("Alerting status")
+
+		if err := g.publisher.Publish(validator.NewStatus(time.Now(), *alertingStatus, pubkey, g.name, g.monitor)); err != nil {
+			g.log.WithError(err).WithField("pubkey", pubkey).WithField("status", *alertingStatus).Error("Error publishing status alert")
 		}
+	}
 
-		if _, exists := g.withdrawalCredentialsAlerts[pubkey]; !exists {
-			g.withdrawalCredentialsAlerts[pubkey] = alert.NewWithdrawalCredentials(g.log, WithdrawalCredentialsCodes)
-		}
+	if shouldAlert, alertingCredential := g.withdrawalCredentialsAlerts[pubkey].Update(codes); shouldAlert {
+		g.log.WithField("credential", *alertingCredential).WithField("pubkey", pubkey).Warn("Alerting withdrawal credentials")
 
-		balanceAlert := g.balanceAlerts[pubkey]
-		statusAlert := g.statusAlerts[pubkey]
-		withdrawalCredentialsAlert := g.withdrawalCredentialsAlerts[pubkey]
-
-		balances := make([]uint64, 0, len(g.validatorState.Validators[pubkey].Sources))
-		statuses := make([]string, 0, len(g.validatorState.Validators[pubkey].Sources))
-		codes := make([]int64, 0, len(g.validatorState.Validators[pubkey].Sources))
-
-		for _, source := range g.validatorState.Validators[pubkey].Sources {
-			balances = append(balances, source.Balance)
-			statuses = append(statuses, string(source.Status))
-			codes = append(codes, source.WithdrawalCredentialsCode)
-		}
-
-		if shouldAlert, balance := balanceAlert.Update(balances); shouldAlert {
-			g.log.WithField("balance", *balance).WithField("pubkey", pubkey).Warn("Alerting min balance")
-
-			if err := g.publisher.Publish(validator.NewMinBalance(time.Now(), *balance, pubkey, g.name, g.monitor)); err != nil {
-				g.log.WithError(err).WithField("pubkey", pubkey).Error("Error publishing min balance alert")
-			}
-		}
-
-		if shouldAlert, alertingStatus := statusAlert.Update(statuses); shouldAlert {
-			g.log.WithField("status", *alertingStatus).WithField("pubkey", pubkey).Warn("Alerting status")
-
-			if err := g.publisher.Publish(validator.NewStatus(time.Now(), *alertingStatus, pubkey, g.name, g.monitor)); err != nil {
-				g.log.WithError(err).WithField("pubkey", pubkey).WithField("status", *alertingStatus).Error("Error publishing status alert")
-			}
-		}
-
-		if shouldAlert, alertingCredential := withdrawalCredentialsAlert.Update(codes); shouldAlert {
-			g.log.WithField("credential", *alertingCredential).WithField("pubkey", pubkey).Warn("Alerting withdrawal credentials")
-
-			if err := g.publisher.Publish(validator.NewWithdrawalCredentials(time.Now(), *alertingCredential, pubkey, g.name, g.monitor)); err != nil {
-				g.log.WithError(err).WithField("pubkey", pubkey).WithField("credential", *alertingCredential).Error("Error publishing withdrawal credentials alert")
-			}
+		if err := g.publisher.Publish(validator.NewWithdrawalCredentials(time.Now(), *alertingCredential, pubkey, g.name, g.monitor)); err != nil {
+			g.log.WithError(err).WithField("pubkey", pubkey).WithField("credential", *alertingCredential).Error("Error publishing withdrawal credentials alert")
 		}
 	}
 }

--- a/pkg/monitor/service/validator/group/metrics.go
+++ b/pkg/monitor/service/validator/group/metrics.go
@@ -101,7 +101,7 @@ func (m Metrics) UpdateTotalWithdrawals(total float64, labels []string) {
 func (m Metrics) UpdateStatus(status MetricsStatus, labels []string) {
 	var statusCode float64
 
-	switch status {
+	switch status { //nolint:exhaustive // MetricsStatusUnknown handled by default
 	case MetricsStatusMempool:
 		statusCode = 1
 	case MetricsStatusDeposited:

--- a/pkg/monitor/service/validator/group/status.go
+++ b/pkg/monitor/service/validator/group/status.go
@@ -32,7 +32,7 @@ const (
 //
 // Offline could be supported by checking the last 3 epochs.
 func BeaconAPIToMetricsStatus(status v1.ValidatorState, slashed bool) MetricsStatus {
-	switch status {
+	switch status { //nolint:exhaustive // only mapping known states, default handles rest
 	case v1.ValidatorStatePendingInitialized:
 		return MetricsStatusDeposited
 	case v1.ValidatorStatePendingQueued:

--- a/pkg/monitor/service/validator/validator.go
+++ b/pkg/monitor/service/validator/validator.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethpandaops/splitoor/pkg/ethereum"
@@ -22,7 +23,7 @@ type Service struct {
 
 func NewService(ctx context.Context, log logrus.FieldLogger, monitor string, config *Config, ethereumPool *ethereum.Pool, publisher *notifier.Publisher, beaconchainClient beaconchain.Client) (*Service, error) {
 	if beaconchainClient == nil && !ethereumPool.HasBeaconNodes() {
-		return nil, fmt.Errorf("no beaconchain client or ethereum beacon nodes configured")
+		return nil, errors.New("no beaconchain client or ethereum beacon nodes configured")
 	}
 
 	groups := make([]*group.Group, 0, len(config.Groups))


### PR DESCRIPTION
## Summary

Upgrades Go from 1.25.1 to 1.26.1, overhauls the golangci-lint configuration with a modern stricter linter set, and applies all necessary fixes across 70 files to achieve full compliance. Also includes targeted refactoring to reduce function complexity and improve Safe API rate limiting resilience.

## Changes

### Go & Build
- **Go 1.26.1**: Updated `go.mod` and `Dockerfile` (golang:1.23 -> golang:1.26)
- **gofumpt**: Switched formatter from `gofmt` to `gofumpt`

### Linter Configuration (`.golangci.yml`)
- **Removed**: asasalint, containedctx, decorder, dogsled, durationcheck, gocyclo, godot, goheader, goprintffuncname, nakedret, nilnil, nlreturn, nosprintfhostport, prealloc, promlinter, reassign, thelper, wsl_v5
- **Added**: cyclop (max 30), dupword, errorlint, exhaustive, exptostd, fatcontext, funlen (100 lines/50 stmts), gocognit (min 20), gocritic, intrange, modernize, nestif, noctx, perfsprint, revive, sloglint, testifylint, tparallel, unparam, usetesting, usestdlibvars, wastedassign
- **Enabled**: strict govet shadow, test file exemptions for funlen/gocognit

### Codebase-Wide Lint Fixes (all 70 files)
| Linter | Fix | Count |
|--------|-----|-------|
| errorlint | `fmt.Errorf("static")` → `errors.New()` | ~50 |
| errorlint | `err == X` → `errors.Is(err, X)`, type assert → `errors.As` | 5 |
| perfsprint | `fmt.Sprintf("%d", x)` → `strconv.Itoa(x)` | ~15 |
| perfsprint | `fmt.Sprintf("prefix %s", x)` → `"prefix " + x` | 4 |
| modernize | `interface{}` → `any` | ~20 |
| testifylint | `assert.Error` → `require.Error` (when gating subsequent code) | ~40 |
| testifylint | `assert.Len(t, x, 0)` → `assert.Empty(t, x)` | 3 |
| intrange | `for i := 0; i < N; i++` → `for range N` / `for i := range x` | 5 |
| noctx | `http.NewRequest` → `http.NewRequestWithContext` | 1 |
| usestdlibvars | `"GET"` → `http.MethodGet` | 4 |
| govet shadow | Variable renames to avoid shadowing (`err` → `startErr`, etc.) | ~15 |
| gosec/exhaustive | Added `//nolint` directives for intentional patterns | 6 |
| errcheck | Test HTTP handlers now check `json.Encode` errors | 8 |
| errorlint | `%v` → `%w` for error wrapping | 3 |

### Refactoring for Complexity Reduction
- **`split/create.go`**: Extracted `waitForTransaction()` method, reused in `distrubte.go` — eliminates duplicated goto-based polling loops
- **`split/group/group.go`**: Extracted `clearStaleHashMetrics()`, `updateHashMetrics()`, `checkHashAlerts()` from monolithic `checkHash()`
- **`split/group/account/account.go`**: Extracted `gatherNodeMetrics()` from nested tick loop
- **`validator/group/group.go`**: Extracted `processBeaconNode()`, `getSingle/MultipleValidatorsBeaconchain()`, `ensureAlerts()`, `checkPubkeyAlerts()` — reduces deeply nested functions
- **`controller/safe/safe.go`**: Removed unused `ctx` parameter from 5 alert methods
- **`smtp/email.go`**: Extracted `sendTLSEmail()` with early-return pattern
- **`config_test.go`**: Converted table-driven test to individual test functions with shared `validBaseConfig()` helper

### Safe API Rate Limiting Improvements
- **Exponential backoff**: Consecutive 429 responses double the delay (capped at 4x) and halve the restore rate (capped at 1/4 base)
- **Coalescing**: Concurrent goroutines hitting 429 share the same pause window instead of each triggering independent pauses
- **Retry loop**: Changed from single retry to loop with `maxRateLimitRetries = 5`, with proper exhaustion error
- **Backoff reset**: Successful (non-429) responses reset the consecutive counter and restore base rate
- **New tests**: `TestClient_RateLimitRetry_MultipleConsecutive429s` and `TestClient_RateLimitRetry_Exhaustion`

### Context Cancellation Handling
- Added `ctx.Err()` checks before logging errors in node iteration loops across account, EOA controller, safe controller, split group, and validator group — prevents noisy error logs during graceful shutdown

### Go 1.26 Idioms
- `sync.WaitGroup`: Use `wg.Go(func(){})` instead of `wg.Add(1)` + `go func(){ defer wg.Done(); ... }()`
- `min()` builtin for slice bound clamping instead of manual if-then
- Pre-sized maps with capacity hints where length is known

## Test plan
- [ ] All existing tests pass (`go test ./...`)
- [ ] `golangci-lint run` passes with new configuration
- [ ] Docker build succeeds with Go 1.26
- [ ] Safe API rate limiting behaves correctly under 429 responses (new tests cover multi-retry and exhaustion)
- [ ] Graceful shutdown does not produce spurious error logs